### PR TITLE
fix: anchors not being output for multibyte characters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ const insertAnchorToHeadings = (
 
   for (let i = 0; i < headings.length; i++) {
     const heading = headings[i];
-    const matchedAnchor = anchorMap.get(heading.id);
+    const matchedAnchor = anchorMap.get(encodeURIComponent(heading.id));
 
     if (!matchedAnchor) {
       continue;


### PR DESCRIPTION
## Overview
Fixed a problem that anchors were not output when id is a multibyte character.

## Reason
When storing multibyte characters in the map, the key was encoded, and the extraction did not match in later processing.