### PR TITLE
[feature] Added the ability to specify a range of heading levels

### DIFF
--- a/__test__/src/App.tsx
+++ b/__test__/src/App.tsx
@@ -1,12 +1,32 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Mokuji, Destroy } from 'mokuji.js';
 
 function App() {
   const ref = useRef<HTMLDivElement>(null);
   const refMokuji = useRef<HTMLDivElement>(null);
+  const [minLevel, setMinLevel] = useState<number>(1);
+  const [maxLevel, setMaxLevel] = useState<number>(6);
 
+  // オプションを関数外で参照できるようにする
+  const mokujiOptionsRef = useRef({
+    minLevel,
+    maxLevel,
+  });
+
+  // オプションの変更を反映
+  useEffect(() => {
+    mokujiOptionsRef.current = {
+      minLevel,
+      maxLevel,
+    };
+  }, [minLevel, maxLevel]);
+
+  // create関数の依存配列から状態変数を除去
   const create = useCallback(() => {
+    // 現在の設定値を参照
+    const { minLevel, maxLevel } = mokujiOptionsRef.current;
+
     const result = Mokuji(ref.current, {
       anchorType: true,
       anchorLink: true,
@@ -14,10 +34,13 @@ function App() {
       anchorLinkPosition: 'before',
       anchorLinkClassName: 'anchor  anchor2  ',
       anchorContainerTagName: 'ol',
+      minLevel,
+      maxLevel,
     });
 
     if (result) {
       if (refMokuji.current) {
+        refMokuji.current.innerHTML = ''; // 既存コンテンツをクリア
         refMokuji.current.append(result.list);
       }
       if (ref.current && result.element) {
@@ -32,10 +55,66 @@ function App() {
     return () => {
       Destroy();
     };
-  }, []);
+  }, [create]);
+
+  // レベル変更時の処理を共通化
+  const handleLevelChange = useCallback(() => {
+    // 目次を再生成する（Destroyで内容をクリアしてからcreateで再生成）
+    if (document.querySelector('[data-mokuji-list]')) {
+      Destroy();
+    }
+    create();
+  }, [create]);
+
+  const handleMinLevelChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const newMinLevel = Number(e.target.value);
+      // 最小レベルが最大レベルを超えないようにする
+      setMinLevel(newMinLevel <= maxLevel ? newMinLevel : maxLevel);
+      // 直ちにhandleLevelChangeを呼び出さない（setStateの後に実行される）
+    },
+    [maxLevel],
+  );
+
+  const handleMaxLevelChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const newMaxLevel = Number(e.target.value);
+      // 最大レベルが最小レベル未満にならないようにする
+      setMaxLevel(newMaxLevel >= minLevel ? newMaxLevel : minLevel);
+      // 直ちにhandleLevelChangeを呼び出さない（setStateの後に実行される）
+    },
+    [minLevel],
+  );
+
+  // レベル変更時に目次を更新
+  useEffect(() => {
+    handleLevelChange();
+  }, [minLevel, maxLevel, handleLevelChange]);
 
   return (
     <main className="container">
+      <div>
+        <div>
+          <label htmlFor="min-level">min level:</label>
+          <select id="min-level" value={minLevel} onChange={handleMinLevelChange}>
+            {[1, 2, 3, 4, 5, 6].map((level) => (
+              <option key={`min-${level}`} value={level}>
+                h{level}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="max-level">max level:</label>
+          <select id="max-level" value={maxLevel} onChange={handleMaxLevelChange}>
+            {[1, 2, 3, 4, 5, 6].map((level) => (
+              <option key={`max-${level}`} value={level}>
+                h{level}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
       <button type="button" onClick={() => create()}>
         Create
       </button>

--- a/__test__/src/App.tsx
+++ b/__test__/src/App.tsx
@@ -55,7 +55,7 @@ function App() {
     return () => {
       Destroy();
     };
-  }, [create]);
+  }, []);
 
   // レベル変更時の処理を共通化
   const handleLevelChange = useCallback(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,4 +9,8 @@ export type MokujiOption = {
   anchorLinkPosition?: 'before' | 'after';
   anchorLinkClassName?: string;
   anchorContainerTagName?: AnchorContainerTagNameProps;
+  /** 最小見出しレベル（例: 1はh1を意味する。これより小さいレベルは表示しない） */
+  minLevel?: number;
+  /** 最大見出しレベル（例: 3はh3を意味する。これより大きいレベルは表示しない） */
+  maxLevel?: number;
 };


### PR DESCRIPTION
close: #167

---

This pull request introduces functionality to filter headings by their level (`minLevel` and `maxLevel`) in the `Mokuji.js` library and updates the example app to allow dynamic control of these levels. The changes improve customization and usability of the library while maintaining backward compatibility.

### Enhancements to `Mokuji.js`:

* Added `minLevel` and `maxLevel` options to filter headings by level in the `Mokuji` function. Headings outside the specified range are excluded from the table of contents. (`src/index.ts`, [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R248-R262) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L252-R276)
* Introduced the helper function `isHeadingWithinLevelRange` to determine if a heading falls within the specified level range. (`src/index.ts`, [src/index.tsR159-R166](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R159-R166))
* Updated the default options to include `minLevel: 1` and `maxLevel: 6`, ensuring default behavior remains unchanged. (`src/index.ts`, [src/index.tsR26-R27](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R26-R27))
* Extended the `MokujiOption` type to include `minLevel` and `maxLevel` with appropriate documentation. (`src/types.ts`, [src/types.tsR12-R15](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR12-R15))

### Updates to the example app:

* Added `minLevel` and `maxLevel` state variables and controls (dropdowns) to dynamically adjust the heading level range for the table of contents. (`__test__/src/App.tsx`, [[1]](diffhunk://#diff-724919183ca0e1fc98cb712ac41033bed71620594637e80ad3090a6ab9e93820L1-R43) [[2]](diffhunk://#diff-724919183ca0e1fc98cb712ac41033bed71620594637e80ad3090a6ab9e93820L35-R117)
* Implemented a mechanism to update the table of contents when `minLevel` or `maxLevel` changes, ensuring the UI reflects the current settings. (`__test__/src/App.tsx`, [__test__/src/App.tsxL35-R117](diffhunk://#diff-724919183ca0e1fc98cb712ac41033bed71620594637e80ad3090a6ab9e93820L35-R117))