### PR TITLE
Refactor TOC generation and heading identity management with tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,24 +56,25 @@ npm run format
 
 ```
 src/
-├── index.ts           # Main API entry point (Mokuji function)
-├── mokuji-core.ts    # Table of contents hierarchy generation (buildTocHierarchy, buildTocDom)
-├── heading.ts        # Heading extraction, filtering, ID management, and RFC 3986 encoding
-├── anchor.ts         # Anchor link generation and insertion with Core pattern implementations
-├── types.ts          # Type definitions (MokujiOption, HeadingLevel, AnchorLinkPosition)
+├── index.ts             # Main API entry point (Mokuji function)
+├── heading.ts           # Heading filtering by level + blockquote; level extraction
+├── heading-identity.ts  # Single-pass identity resolver (pure) + DOM writer
+├── mokuji-core.ts       # TOC list DOM builder (consumes ResolvedHeading[])
+├── anchor.ts            # Per-heading anchor link insertion
+├── types.ts             # Type definitions (MokujiOption, HeadingLevel, AnchorLinkPosition)
 ├── utils/
-│   ├── constants.ts  # Default options and data attributes
-│   └── dom.ts        # DOM manipulation utilities
-└── *.test.ts         # Test files alongside source files
+│   ├── constants.ts     # Default options and data attributes
+│   └── dom.ts           # DOM manipulation utilities
+└── *.test.ts            # Test files alongside source files
 ```
+
+See `CONTEXT.md` for domain vocabulary (`heading identity`, `resolved heading`, `TOC list anchor`, `per-heading anchor`).
 
 ### Core Patterns
 
 1. **Functional Composition**: Main `Mokuji()` orchestrates smaller pure functions
-2. **Two-Phase Processing**:
-   - Phase 1: Extract headings → Filter by levels
-   - Phase 2: Build hierarchy → Generate anchors
-3. **Stack-based Hierarchy**: Uses array stack for nested list structure
+2. **Single-Pass Identity Resolution**: `resolveHeadingIdentities` decides each heading's final unique ID before any DOM is built; `commitHeadingIdentities` writes those IDs once. Downstream consumers (TOC list, per-heading anchors) all derive `href` from `ResolvedHeading.identity` directly — no map lookup or fallback search
+3. **Stack-based Hierarchy**: TOC tree built with an array stack for nested list structure
 4. **Instance-scoped Cleanup**: Each call returns its own `destroy()` function
 5. **DOM Abstraction**: All DOM operations centralized in `utils/dom.ts`
 
@@ -112,11 +113,17 @@ Following principles from industry leaders:
 - Prefer pure functions with single responsibilities
 - Avoid mutations, prefer immutable updates
 
-### DRY Pattern with Core Suffix
+### Heading Identity Pipeline
 
-- Internal implementations use `*Core` suffix (e.g., `buildMokujiHierarchy` calls `buildTocHierarchyCore`)
-- Maintains public API compatibility while consolidating logic
-- Avoids code duplication while keeping clear API boundaries
+The pipeline orchestrated by `Mokuji()`:
+
+1. `getFilteredHeadings(element, ...)` — DOM query + level / blockquote filter
+2. `resolveHeadingIdentities(headings, { anchorType })` — pure: returns `ResolvedHeading[]` with final unique identities
+3. `commitHeadingIdentities(resolved)` — side effect: writes `heading.id`
+4. `buildTocList(resolved, tag)` — pure render of nested `<ol>` / `<ul>` from resolved headings
+5. `insertPerHeadingAnchors(resolved, options)` — optional `data-mokuji-anchor` injection per heading (when `anchorLink: true`)
+
+`ResolvedHeading.identity` is the single source of truth — `heading.id`, TOC list anchor `href`, and per-heading anchor `href` all derive from it. The encoding strategy (Wikipedia-style vs RFC 3986) and dedup rules are private to `heading-identity.ts`.
 
 ### Anchor Encoding Logic
 
@@ -161,7 +168,7 @@ Following principles from industry leaders:
 ## Recent Architectural Decisions
 
 - **RFC 3986 Compliance**: Standard anchor generation (`anchorType: false`) now uses proper URL encoding via `encodeURIComponent`
-- **Refactoring Pattern**: Core functions use internal `*Core` suffix pattern to consolidate logic while maintaining backward compatibility
+- **Single-Pass Identity Resolution**: Heading identities are resolved in one pure pass (`resolveHeadingIdentities`) before any rendering, replacing the prior two-pass DOM-mutating sequence and the multi-strategy anchor matcher. The `*Core` suffix indirection and the anchor `Map`-based lookup machinery were removed.
 - **Coverage Strategy**: Type-only files (`types.ts`) and test files are excluded from coverage metrics
 - **Build Tool Migration**: Moved from tsup to tsdown for better ESM support and build performance
 - **Blockquote Heading Exclusion**: Headings inside `<blockquote>` elements are excluded from TOC by default (`includeBlockquoteHeadings: false`), configurable via option
@@ -169,7 +176,7 @@ Following principles from industry leaders:
 ## Important Notes
 
 - **No TypeScript Classes**: Avoid using TypeScript classes. Prefer functional programming patterns and object literals.
-- **DRY Principle**: Internal implementations use `*Core` suffix pattern to avoid duplication while maintaining public API compatibility.
+- **Single Source of Truth for Identity**: `ResolvedHeading.identity` is the only authority for `heading.id` and any anchor `href`. Do not reintroduce parallel anchor-matching paths (text fallback, suffix-stripped lookup).
 - **Anchor Generation**:
   - When `anchorType: true` (Wikipedia-style): Spaces become underscores, then percent-encoded with dots replacing %
   - When `anchorType: false` (RFC 3986 compliant): Uses standard `encodeURIComponent`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,30 @@
+# Domain Vocabulary
+
+`mokuji.js` (Japanese for "table of contents") generates a hierarchical TOC — a nested list of links — from heading elements (`h1`–`h6`) inside an HTML container.
+
+Terms used in this codebase. Keep in sync with code as concepts evolve.
+
+## heading identity
+
+The final, unique, user-facing ID assigned to a heading element after all of:
+
+- preserving an author-provided `id` attribute when present,
+- generating an ID from `textContent` when absent (Wikipedia-style or RFC 3986 percent-encoded, depending on `anchorType`),
+- deduplicating across the heading set with the `_N` suffix scheme,
+- preserving any pre-existing `aaa_N`-shaped IDs so that suffix assignment skips over reserved values.
+
+A heading identity is the single source of truth for the heading's `id` attribute, the TOC list anchor's `href`, and the per-heading anchor's `href`. All three derive from the same identity; they are not reconciled separately.
+
+## resolved heading
+
+A heading element paired with its computed `heading identity` and level. The output of identity resolution and the input to TOC tree construction and per-heading anchor insertion.
+
+Resolved headings are produced by a pure function; committing the identity to the DOM (`heading.id = identity`) is a separate writer step.
+
+## TOC list anchor
+
+The `<a>` element inside the generated `<ol>`/`<ul>` list. Its `href` points at a heading identity.
+
+## per-heading anchor
+
+The `<a>` element inserted *into* a heading (controlled by the `anchorLink` option). Distinct from the TOC list anchor; carries `data-mokuji-anchor`. Its `href` also points at the same heading identity.

--- a/__sandbox__/src/App.tsx
+++ b/__sandbox__/src/App.tsx
@@ -1,45 +1,27 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react';
 
 import { Mokuji, type HeadingLevel } from 'mokuji.js';
+
+type MokujiInstance = ReturnType<typeof Mokuji>;
 
 function App() {
   const ref = useRef<HTMLDivElement>(null);
   const refMokuji = useRef<HTMLDivElement>(null);
+  const mokujiInstanceRef = useRef<MokujiInstance>(undefined);
+
   const [minLevel, setMinLevel] = useState<HeadingLevel>(1);
   const [maxLevel, setMaxLevel] = useState<HeadingLevel>(6);
   const [includeBlockquoteHeadings, setIncludeBlockquoteHeadings] = useState(false);
-  const mokujiInstanceRef = useRef<ReturnType<typeof Mokuji> | undefined>(undefined);
 
-  // オプションを関数外で参照できるようにする
-  const mokujiOptionsRef = useRef({
-    minLevel,
-    maxLevel,
-    includeBlockquoteHeadings,
-  });
+  const destroyMokuji = useCallback(() => {
+    mokujiInstanceRef.current?.destroy();
+    mokujiInstanceRef.current = undefined;
+    if (refMokuji.current) refMokuji.current.innerHTML = '';
+  }, []);
 
-  // オプションの変更を反映
-  useEffect(() => {
-    mokujiOptionsRef.current = {
-      minLevel,
-      maxLevel,
-      includeBlockquoteHeadings,
-    };
-  }, [minLevel, maxLevel, includeBlockquoteHeadings]);
-
-  // create関数の依存配列から状態変数を除去
   const create = useCallback(() => {
-    // 既存のインスタンスがあれば破棄
-    if (mokujiInstanceRef.current) {
-      mokujiInstanceRef.current.destroy();
-      mokujiInstanceRef.current = undefined;
-    }
-
-    // 現在の設定値を参照
-    const { minLevel, maxLevel, includeBlockquoteHeadings } = mokujiOptionsRef.current;
-
-    if (!ref.current) {
-      return;
-    }
+    destroyMokuji();
+    if (!ref.current) return;
 
     const result = Mokuji(ref.current, {
       anchorType: true,
@@ -55,57 +37,24 @@ function App() {
 
     if (result) {
       mokujiInstanceRef.current = result;
-      if (refMokuji.current) {
-        refMokuji.current.innerHTML = ''; // 既存コンテンツをクリア
-        refMokuji.current.append(result.list);
-      }
-      if (ref.current && result.element) {
-        ref.current.innerHTML = result.element.innerHTML;
-      }
+      refMokuji.current?.append(result.list);
     }
-  }, []);
+  }, [minLevel, maxLevel, includeBlockquoteHeadings, destroyMokuji]);
 
   useEffect(() => {
     create();
+    return destroyMokuji;
+  }, [create, destroyMokuji]);
 
-    return () => {
-      if (mokujiInstanceRef.current) {
-        mokujiInstanceRef.current.destroy();
-        mokujiInstanceRef.current = undefined;
-      }
-    };
-  }, []);
+  const handleMinLevelChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const next = Number(e.target.value);
+    setMinLevel(Math.min(next, maxLevel) as HeadingLevel);
+  };
 
-  // レベル変更時の処理を共通化
-  const handleLevelChange = useCallback(() => {
-    // 目次を再生成する
-    create();
-  }, [create]);
-
-  const handleMinLevelChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const newMinLevel = Number(e.target.value);
-      // 最小レベルが最大レベルを超えないようにする
-      setMinLevel(Math.min(newMinLevel, maxLevel) as HeadingLevel);
-      // 直ちにhandleLevelChangeを呼び出さない（setStateの後に実行される）
-    },
-    [maxLevel],
-  );
-
-  const handleMaxLevelChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const newMaxLevel = Number(e.target.value);
-      // 最大レベルが最小レベル未満にならないようにする
-      setMaxLevel(Math.max(newMaxLevel, minLevel) as HeadingLevel);
-      // 直ちにhandleLevelChangeを呼び出さない（setStateの後に実行される）
-    },
-    [minLevel],
-  );
-
-  // オプション変更時に目次を更新
-  useEffect(() => {
-    handleLevelChange();
-  }, [minLevel, maxLevel, includeBlockquoteHeadings, handleLevelChange]);
+  const handleMaxLevelChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const next = Number(e.target.value);
+    setMaxLevel(Math.max(next, minLevel) as HeadingLevel);
+  };
 
   return (
     <main className="container">
@@ -141,21 +90,10 @@ function App() {
           </label>
         </div>
       </div>
-      <button type="button" onClick={() => create()}>
+      <button type="button" onClick={create}>
         Create
       </button>
-      <button
-        type="button"
-        onClick={() => {
-          if (mokujiInstanceRef.current) {
-            mokujiInstanceRef.current.destroy();
-            mokujiInstanceRef.current = undefined;
-            if (refMokuji.current) {
-              refMokuji.current.innerHTML = '';
-            }
-          }
-        }}
-      >
+      <button type="button" onClick={destroyMokuji}>
         Destroy
       </button>
       <div className="grid">

--- a/src/anchor.test.ts
+++ b/src/anchor.test.ts
@@ -1,19 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import {
-  createAnchorMap,
-  findAnchorById,
-  findAnchorByIdWithoutSuffix,
-  findAnchorByText,
-  findMatchingAnchor,
-  applyClassNamesToElement,
-  createAnchorElement,
-  createAnchorForHeading,
-  insertAnchorsIntoHeadings,
-} from './anchor';
+import { insertPerHeadingAnchors } from './anchor';
 import { ANCHOR_DATASET_ATTRIBUTE, defaultOptions } from './utils/constants';
-import type { MokujiOption } from './types';
+import type { ResolvedHeading } from './heading-identity';
+import type { HeadingLevel, MokujiOption } from './types';
 
-describe('anchor', () => {
+const r = (heading: HTMLHeadingElement, identity: string, level: HeadingLevel): ResolvedHeading => ({
+  heading,
+  identity,
+  level,
+});
+
+describe('insertPerHeadingAnchors', () => {
   let container: HTMLElement;
 
   beforeEach(() => {
@@ -25,426 +22,86 @@ describe('anchor', () => {
     container.remove();
   });
 
-  // ========================================
-  // Anchor Map Generation Tests
-  // ========================================
+  it('inserts an anchor before each heading by default', () => {
+    const heading = document.createElement('h2');
+    heading.textContent = 'Test Heading';
+    container.append(heading);
 
-  describe('createAnchorMap', () => {
-    it('generates empty Map from empty array', () => {
-      const result = createAnchorMap([]);
-      expect(result).toBeInstanceOf(Map);
-      expect(result.size).toBe(0);
-    });
+    const inserted = insertPerHeadingAnchors([r(heading, 'test', 2)], defaultOptions);
 
-    it('creates Map with hash as key from anchor elements', () => {
-      const anchor1 = document.createElement('a');
-      anchor1.href = '#heading-1';
-      const anchor2 = document.createElement('a');
-      anchor2.href = '#heading-2';
-
-      const result = createAnchorMap([anchor1, anchor2]);
-
-      expect(result.size).toBe(2);
-      expect(result.get('heading-1')).toBe(anchor1);
-      expect(result.get('heading-2')).toBe(anchor2);
-    });
-
-    it('ignores anchors with empty hash', () => {
-      const anchor1 = document.createElement('a');
-      anchor1.href = '#';
-      const anchor2 = document.createElement('a');
-      anchor2.href = '#heading-1';
-
-      const result = createAnchorMap([anchor1, anchor2]);
-
-      expect(result.size).toBe(1);
-      expect(result.has('')).toBe(false);
-      expect(result.get('heading-1')).toBe(anchor2);
-    });
-
-    it('retains the last one when multiple anchors have the same hash', () => {
-      const anchor1 = document.createElement('a');
-      anchor1.href = '#duplicate';
-      anchor1.textContent = 'First';
-      const anchor2 = document.createElement('a');
-      anchor2.href = '#duplicate';
-      anchor2.textContent = 'Second';
-
-      const result = createAnchorMap([anchor1, anchor2]);
-
-      expect(result.size).toBe(1);
-      expect(result.get('duplicate')).toBe(anchor2);
-    });
+    expect(inserted).toHaveLength(1);
+    const anchor = heading.querySelector(`[${ANCHOR_DATASET_ATTRIBUTE}]`) as HTMLAnchorElement | null;
+    expect(anchor).toBeTruthy();
+    expect(anchor?.textContent).toBe(defaultOptions.anchorLinkSymbol);
+    expect(anchor?.getAttribute('href')).toBe('#test');
+    expect(anchor).toBe(heading.firstElementChild);
   });
 
-  // ========================================
-  // Anchor Finding Tests
-  // ========================================
+  it('places the anchor at the end when anchorLinkPosition is "after"', () => {
+    const heading = document.createElement('h2');
+    heading.textContent = 'Test';
+    container.append(heading);
 
-  describe('findAnchorById', () => {
-    it('searches for anchor with matching ID directly', () => {
-      const anchor1 = document.createElement('a');
-      const anchor2 = document.createElement('a');
-      const anchorMap = new Map([
-        ['heading1', anchor1],
-        ['heading2', anchor2],
-      ]);
+    const options: Required<MokujiOption> = {
+      ...defaultOptions,
+      anchorLinkSymbol: '🔗',
+      anchorLinkPosition: 'after',
+    };
 
-      expect(findAnchorById(anchorMap, 'heading1')).toBe(anchor1);
-      expect(findAnchorById(anchorMap, 'heading2')).toBe(anchor2);
-      expect(findAnchorById(anchorMap, 'not-exist')).toBeUndefined();
-    });
+    insertPerHeadingAnchors([r(heading, 'test', 2)], options);
+
+    const anchor = heading.querySelector(`[${ANCHOR_DATASET_ATTRIBUTE}]`);
+    expect(anchor).toBe(heading.lastElementChild);
+    expect(anchor?.textContent).toBe('🔗');
   });
 
-  describe('findAnchorByIdWithoutSuffix', () => {
-    it('searches for ID after removing numeric suffix', () => {
-      const anchor1 = document.createElement('a');
-      const anchor2 = document.createElement('a');
-      const anchorMap = new Map([
-        ['overview', anchor1],
-        ['installation', anchor2],
-      ]);
+  it('removes a previously-inserted anchor before inserting a new one', () => {
+    const heading = document.createElement('h2');
+    heading.textContent = 'Test Heading';
 
-      // Search from ID with suffix
-      expect(findAnchorByIdWithoutSuffix(anchorMap, 'overview_1')).toBe(anchor1);
-      expect(findAnchorByIdWithoutSuffix(anchorMap, 'overview_2')).toBe(anchor1);
-      expect(findAnchorByIdWithoutSuffix(anchorMap, 'installation_10')).toBe(anchor2);
-    });
+    const stale = document.createElement('a');
+    stale.setAttribute(ANCHOR_DATASET_ATTRIBUTE, '');
+    stale.textContent = 'old';
+    heading.append(stale);
+    container.append(heading);
 
-    it('returns undefined when ID has no suffix', () => {
-      const anchorMap = new Map([['overview', document.createElement('a')]]);
+    const options: Required<MokujiOption> = { ...defaultOptions, anchorLinkSymbol: 'new' };
+    insertPerHeadingAnchors([r(heading, 'test', 2)], options);
 
-      // undefined when no suffix
-      expect(findAnchorByIdWithoutSuffix(anchorMap, 'overview')).toBeUndefined();
-      expect(findAnchorByIdWithoutSuffix(anchorMap, 'not_exist')).toBeUndefined();
-    });
-
-    it('contains underscore but is not a suffix', () => {
-      const anchor = document.createElement('a');
-      const anchorMap = new Map([['user_profile', anchor]]);
-
-      // user_profile is not a suffix
-      expect(findAnchorByIdWithoutSuffix(anchorMap, 'user_profile')).toBeUndefined();
-      // user_profile_1 has a suffix
-      expect(findAnchorByIdWithoutSuffix(anchorMap, 'user_profile_1')).toBe(anchor);
-    });
+    const anchors = heading.querySelectorAll(`[${ANCHOR_DATASET_ATTRIBUTE}]`);
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0].textContent).toBe('new');
   });
 
-  describe('findAnchorByText', () => {
-    it('searches for anchor by text content', () => {
-      const anchor1 = document.createElement('a');
-      anchor1.textContent = 'Introduction';
-      const anchor2 = document.createElement('a');
-      anchor2.textContent = 'Getting Started';
-      const anchorMap = new Map([
-        ['intro', anchor1],
-        ['start', anchor2],
-      ]);
+  it('applies anchorLinkClassName to inserted anchors', () => {
+    const heading = document.createElement('h2');
+    heading.textContent = 'Test';
+    container.append(heading);
 
-      expect(findAnchorByText(anchorMap, 'Introduction')).toBe(anchor1);
-      expect(findAnchorByText(anchorMap, 'Getting Started')).toBe(anchor2);
-      expect(findAnchorByText(anchorMap, 'Not Found')).toBeUndefined();
-    });
+    const options: Required<MokujiOption> = { ...defaultOptions, anchorLinkClassName: 'cls-a cls-b' };
+    insertPerHeadingAnchors([r(heading, 'test', 2)], options);
 
-    it('searches ignoring leading/trailing whitespace', () => {
-      const anchor = document.createElement('a');
-      anchor.textContent = '  Trimmed Text  ';
-      const anchorMap = new Map([['trimmed', anchor]]);
-
-      expect(findAnchorByText(anchorMap, 'Trimmed Text')).toBe(anchor);
-      expect(findAnchorByText(anchorMap, '  Trimmed Text  ')).toBe(anchor);
-    });
-
-    it('returns undefined for empty string', () => {
-      const anchorMap = new Map([['test', document.createElement('a')]]);
-
-      expect(findAnchorByText(anchorMap, '')).toBeUndefined();
-      expect(findAnchorByText(anchorMap, '  ')).toBeUndefined();
-    });
+    const anchor = heading.querySelector(`[${ANCHOR_DATASET_ATTRIBUTE}]`);
+    expect(anchor?.classList.contains('cls-a')).toBe(true);
+    expect(anchor?.classList.contains('cls-b')).toBe(true);
   });
 
-  describe('findMatchingAnchor', () => {
-    it('Priority 1: when ID matches directly', () => {
-      const directMatch = document.createElement('a');
-      directMatch.textContent = 'Direct';
-      const suffixMatch = document.createElement('a');
-      suffixMatch.textContent = 'Suffix';
-      const textMatch = document.createElement('a');
-      textMatch.textContent = 'Text Match';
+  it('inserts one anchor per resolved heading', () => {
+    const h1 = document.createElement('h2');
+    h1.textContent = 'A';
+    const h2 = document.createElement('h2');
+    h2.textContent = 'B';
+    container.append(h1, h2);
 
-      const anchorMap = new Map([
-        ['heading1', directMatch],
-        ['heading', suffixMatch], // Matches after removing suffix from heading1_1
-        ['other', textMatch],
-      ]);
+    const inserted = insertPerHeadingAnchors([r(h1, 'a', 2), r(h2, 'b', 2)], defaultOptions);
 
-      // Direct ID match has highest priority
-      expect(findMatchingAnchor(anchorMap, 'heading1', 'Text Match')).toBe(directMatch);
-    });
-
-    it('Priority 2: when ID matches after suffix removal', () => {
-      const suffixMatch = document.createElement('a');
-      suffixMatch.textContent = 'Suffix Match';
-      const textMatch = document.createElement('a');
-      textMatch.textContent = 'Duplicate Heading';
-
-      const anchorMap = new Map([
-        ['overview', suffixMatch],
-        ['other', textMatch],
-      ]);
-
-      // No direct match, matches with suffix removal
-      expect(findMatchingAnchor(anchorMap, 'overview_2', 'Duplicate Heading')).toBe(suffixMatch);
-    });
-
-    it('Priority 3: when text content matches', () => {
-      const textMatch = document.createElement('a');
-      textMatch.textContent = 'Installation Guide';
-
-      const anchorMap = new Map([['different-id', textMatch]]);
-
-      // No ID match, matches by text
-      expect(findMatchingAnchor(anchorMap, 'install_3', 'Installation Guide')).toBe(textMatch);
-    });
-
-    it('when not found by any fallback', () => {
-      const anchor = document.createElement('a');
-      anchor.textContent = 'Different Text';
-
-      const anchorMap = new Map([['different', anchor]]);
-
-      expect(findMatchingAnchor(anchorMap, 'not-found', 'No Match')).toBeUndefined();
-    });
+    expect(inserted).toHaveLength(2);
+    expect(h1.querySelectorAll(`[${ANCHOR_DATASET_ATTRIBUTE}]`)).toHaveLength(1);
+    expect(h2.querySelectorAll(`[${ANCHOR_DATASET_ATTRIBUTE}]`)).toHaveLength(1);
   });
 
-  // ========================================
-  // Anchor Factory Tests
-  // ========================================
-
-  describe('applyClassNamesToElement', () => {
-    it('applies single class name', () => {
-      const element = document.createElement('div');
-      applyClassNamesToElement(element, 'test-class');
-
-      expect(element.classList.contains('test-class')).toBe(true);
-    });
-
-    it('applies multiple class names', () => {
-      const element = document.createElement('div');
-      applyClassNamesToElement(element, 'class1 class2 class3');
-
-      expect(element.classList.contains('class1')).toBe(true);
-      expect(element.classList.contains('class2')).toBe(true);
-      expect(element.classList.contains('class3')).toBe(true);
-    });
-
-    it('does not add classes for empty string', () => {
-      const element = document.createElement('div');
-      const originalClassListLength = element.classList.length;
-      applyClassNamesToElement(element, '');
-
-      expect(element.classList.length).toBe(originalClassListLength);
-    });
-
-    it('adds new classes while preserving existing ones', () => {
-      const element = document.createElement('div');
-      element.classList.add('existing-class');
-      applyClassNamesToElement(element, 'new-class');
-
-      expect(element.classList.contains('existing-class')).toBe(true);
-      expect(element.classList.contains('new-class')).toBe(true);
-    });
-  });
-
-  describe('createAnchorElement', () => {
-    it('creates basic anchor template', () => {
-      const anchor = createAnchorElement(defaultOptions);
-
-      expect(anchor).toBeInstanceOf(HTMLAnchorElement);
-      expect(anchor.dataset.mokujiAnchor).toBe('');
-      // Template does not have textContent (set during clone)
-      expect(anchor.textContent).toBe('');
-    });
-
-    it('when class name is empty with default options', () => {
-      const anchor = createAnchorElement(defaultOptions);
-
-      // By default anchorLinkClassName is empty so no class is added
-      expect(anchor.classList.length).toBe(0);
-    });
-
-    it('applies custom class name', () => {
-      const options = { ...defaultOptions, anchorLinkClassName: 'custom-anchor-class' };
-      const anchor = createAnchorElement(options);
-
-      expect(anchor.classList.contains('custom-anchor-class')).toBe(true);
-    });
-  });
-
-  describe('createAnchorForHeading', () => {
-    it('handles safely even when heading textContent is null', () => {
-      const heading = document.createElement('h2');
-      heading.id = 'test-heading';
-      Object.defineProperty(heading, 'textContent', {
-        value: undefined,
-        writable: true,
-        configurable: true,
-      });
-
-      const anchorTemplate = createAnchorElement(defaultOptions);
-      const anchorMap = new Map<string, HTMLAnchorElement>();
-      const tocAnchor = document.createElement('a');
-      tocAnchor.href = '#test-heading';
-      anchorMap.set('test-heading', tocAnchor);
-
-      const result = createAnchorForHeading(heading, anchorMap, anchorTemplate, defaultOptions);
-
-      expect(result).toBeDefined();
-      expect(result?.href).toContain('#test-heading');
-    });
-
-    it('returns undefined when no matching anchor is found', () => {
-      const heading = document.createElement('h2');
-      heading.id = 'no-match';
-      heading.textContent = 'No Match';
-
-      const anchorTemplate = createAnchorElement(defaultOptions);
-      const anchorMap = new Map<string, HTMLAnchorElement>();
-      // No corresponding entry in anchorMap
-
-      const result = createAnchorForHeading(heading, anchorMap, anchorTemplate, defaultOptions);
-
-      expect(result).toBeUndefined();
-    });
-  });
-
-  // ========================================
-  // Anchor Insertion Tests
-  // ========================================
-
-  describe('insertAnchorsIntoHeadings', () => {
-    it('inserts anchor links into headings', () => {
-      const heading = document.createElement('h2');
-      heading.id = 'test-heading';
-      heading.textContent = 'Test Heading';
-      container.append(heading);
-
-      const tocAnchor = document.createElement('a');
-      tocAnchor.href = '#test-heading';
-      const anchorMap = new Map([['test-heading', tocAnchor]]);
-
-      const options = {
-        anchorType: true,
-        anchorLink: true,
-        anchorLinkSymbol: '#',
-        anchorLinkPosition: 'before' as const,
-        anchorLinkClassName: 'anchor-link',
-        anchorContainerTagName: 'ol' as const,
-        minLevel: 1 as const,
-        maxLevel: 6 as const,
-        includeBlockquoteHeadings: false,
-      } satisfies Required<MokujiOption>;
-
-      const insertedAnchors = insertAnchorsIntoHeadings([heading], anchorMap, options);
-      expect(insertedAnchors).toHaveLength(1);
-
-      const insertedAnchor = heading.querySelector(`[${ANCHOR_DATASET_ATTRIBUTE}]`);
-      expect(insertedAnchor).toBeTruthy();
-      expect(insertedAnchor?.textContent).toBe('#');
-    });
-
-    it('places anchor at the end of heading when anchorLinkPosition="after"', () => {
-      const heading = document.createElement('h2');
-      heading.id = 'test-heading';
-      heading.textContent = 'Test Heading';
-      container.append(heading);
-
-      const tocAnchor = document.createElement('a');
-      tocAnchor.href = '#test-heading';
-      const anchorMap = new Map([['test-heading', tocAnchor]]);
-
-      const options = {
-        anchorType: true,
-        anchorLink: true,
-        anchorLinkSymbol: '🔗',
-        anchorLinkPosition: 'after' as const,
-        anchorLinkClassName: '',
-        anchorContainerTagName: 'ol' as const,
-        minLevel: 1 as const,
-        maxLevel: 6 as const,
-        includeBlockquoteHeadings: false,
-      } satisfies Required<MokujiOption>;
-
-      const insertedAnchors = insertAnchorsIntoHeadings([heading], anchorMap, options);
-      expect(insertedAnchors).toHaveLength(1);
-
-      const insertedAnchor = heading.querySelector(`[${ANCHOR_DATASET_ATTRIBUTE}]`);
-      expect(insertedAnchor).toBeTruthy();
-      expect(insertedAnchor).toBe(heading.lastElementChild);
-      expect(insertedAnchor?.textContent).toBe('🔗');
-    });
-
-    it('removes existing anchors before inserting new ones', () => {
-      const heading = document.createElement('h2');
-      heading.id = 'test-heading';
-      heading.textContent = 'Test Heading';
-
-      // Add existing anchor
-      const existingAnchor = document.createElement('a');
-      existingAnchor.setAttribute(ANCHOR_DATASET_ATTRIBUTE, '');
-      existingAnchor.textContent = 'old';
-      heading.append(existingAnchor);
-      container.append(heading);
-
-      const tocAnchor = document.createElement('a');
-      tocAnchor.href = '#test-heading';
-      const anchorMap = new Map([['test-heading', tocAnchor]]);
-
-      const options = {
-        anchorType: true,
-        anchorLink: true,
-        anchorLinkSymbol: 'new',
-        anchorLinkPosition: 'before' as const,
-        anchorLinkClassName: '',
-        anchorContainerTagName: 'ol' as const,
-        minLevel: 1 as const,
-        maxLevel: 6 as const,
-        includeBlockquoteHeadings: false,
-      } satisfies Required<MokujiOption>;
-
-      const insertedAnchors = insertAnchorsIntoHeadings([heading], anchorMap, options);
-      expect(insertedAnchors).toHaveLength(1);
-
-      const anchors = heading.querySelectorAll(`[${ANCHOR_DATASET_ATTRIBUTE}]`);
-      expect(anchors).toHaveLength(1);
-      expect(anchors[0].textContent).toBe('new');
-    });
-
-    it('skips headings with no corresponding anchor', () => {
-      const heading = document.createElement('h2');
-      heading.id = 'test-heading';
-      heading.textContent = 'Test Heading';
-      container.append(heading);
-
-      const anchorMap = new Map(); // Empty Map
-
-      const options = {
-        anchorType: true,
-        anchorLink: true,
-        anchorLinkSymbol: '#',
-        anchorLinkPosition: 'before' as const,
-        anchorLinkClassName: '',
-        anchorContainerTagName: 'ol' as const,
-        minLevel: 1 as const,
-        maxLevel: 6 as const,
-        includeBlockquoteHeadings: false,
-      } satisfies Required<MokujiOption>;
-
-      const insertedAnchors = insertAnchorsIntoHeadings([heading], anchorMap, options);
-      expect(insertedAnchors).toHaveLength(0); // No insertion because Map is empty
-
-      const insertedAnchor = heading.querySelector(`[${ANCHOR_DATASET_ATTRIBUTE}]`);
-      expect(insertedAnchor).toBeNull();
-    });
+  it('returns an empty array when no resolved headings are provided', () => {
+    const inserted = insertPerHeadingAnchors([], defaultOptions);
+    expect(inserted).toEqual([]);
   });
 });

--- a/src/anchor.ts
+++ b/src/anchor.ts
@@ -1,197 +1,25 @@
 import { createElement, removeAllElements } from './utils/dom';
 import { ANCHOR_DATASET_ATTRIBUTE } from './utils/constants';
 import type { MokujiOption, AnchorLinkPosition } from './types';
+import type { ResolvedHeading } from './heading-identity';
 
-/**
- * Creates a map from anchor elements within the table of contents, using their href hash values as keys
- */
-export const createAnchorMap = (anchors: HTMLAnchorElement[]): Map<string, HTMLAnchorElement> => {
-  const result = new Map<string, HTMLAnchorElement>();
-
-  for (const anchor of anchors) {
-    if (anchor.hash && anchor.hash.length > 1) {
-      result.set(anchor.hash.slice(1), anchor);
-    }
-  }
-
-  return result;
+const createAnchorTemplate = (className: string): HTMLAnchorElement => {
+  const template = createElement('a');
+  template.setAttribute(ANCHOR_DATASET_ATTRIBUTE, '');
+  const trimmed = className.trim();
+  if (trimmed) template.className = trimmed;
+  return template;
 };
 
-/**
- * Creates a map with anchor element text content as keys
- */
-export const createTextToAnchorMap = (anchors: HTMLAnchorElement[]): Map<string, HTMLAnchorElement> => {
-  const result = new Map<string, HTMLAnchorElement>();
-
-  for (const anchor of anchors) {
-    const text = anchor.textContent?.trim();
-    if (text) {
-      result.set(text, anchor);
-    }
-  }
-
-  return result;
-};
-
-/**
- * Search directly by ID from the anchor map
- */
-export const findAnchorById = (
-  anchorMap: Map<string, HTMLAnchorElement>,
-  id: string,
-): HTMLAnchorElement | undefined => {
-  return anchorMap.get(id);
-};
-
-/**
- * Search by ID with numeric suffix removed
- */
-export const findAnchorByIdWithoutSuffix = (
-  anchorMap: Map<string, HTMLAnchorElement>,
-  id: string,
-): HTMLAnchorElement | undefined => {
-  const idWithoutSuffix = id.replace(/_\d+$/, '');
-  if (idWithoutSuffix !== id) {
-    return anchorMap.get(idWithoutSuffix);
-  }
-  return undefined;
-};
-
-/**
- * Search for anchor by text content
- */
-export const findAnchorByText = (
-  anchorMap: Map<string, HTMLAnchorElement>,
-  text: string,
-): HTMLAnchorElement | undefined => {
-  const trimmedText = text.trim();
-  if (!trimmedText) return undefined;
-
-  for (const anchor of anchorMap.values()) {
-    if (anchor.textContent?.trim() === trimmedText) {
-      return anchor;
-    }
-  }
-  return undefined;
-};
-
-const findAnchorInTextMap = (
-  textToAnchorMap: Map<string, HTMLAnchorElement>,
-  text: string,
-): HTMLAnchorElement | undefined => {
-  const trimmedText = text.trim();
-  if (!trimmedText) return undefined;
-
-  return textToAnchorMap.get(trimmedText);
-};
-
-/**
- * Find matching anchor with 3-level fallback (core implementation)
- */
-const findMatchingAnchorCore = (
-  anchorMap: Map<string, HTMLAnchorElement>,
-  headingId: string,
-  headingText: string,
-  textToAnchorMap?: Map<string, HTMLAnchorElement>,
-): HTMLAnchorElement | undefined => {
-  // 1. Direct ID search → 2. Search after suffix removal → 3. Search by text content
-  const directMatch = findAnchorById(anchorMap, headingId);
-  if (directMatch) return directMatch;
-
-  const suffixMatch = findAnchorByIdWithoutSuffix(anchorMap, headingId);
-  if (suffixMatch) return suffixMatch;
-
-  if (textToAnchorMap) {
-    return findAnchorInTextMap(textToAnchorMap, headingText);
-  }
-
-  return findAnchorByText(anchorMap, headingText);
-};
-
-/**
- * Find matching anchor with 3-level fallback
- */
-export const findMatchingAnchor = (
-  anchorMap: Map<string, HTMLAnchorElement>,
-  headingId: string,
-  headingText: string,
-): HTMLAnchorElement | undefined => {
-  return findMatchingAnchorCore(anchorMap, headingId, headingText);
-};
-
-/**
- * Apply multiple class names to an element
- */
-export const applyClassNamesToElement = (element: HTMLElement, classNameString: string): void => {
-  const trimmedClassNames = classNameString.trim();
-  if (!trimmedClassNames) return;
-
-  element.classList.add(...trimmedClassNames.split(/\s+/).filter(Boolean));
-};
-
-/**
- * Create anchor template element
- */
-export const createAnchorElement = (options: Required<MokujiOption>): HTMLAnchorElement => {
-  const anchorTemplate = createElement('a');
-  anchorTemplate.setAttribute(ANCHOR_DATASET_ATTRIBUTE, '');
-
-  applyClassNamesToElement(anchorTemplate, options.anchorLinkClassName);
-
-  return anchorTemplate;
-};
-
-/**
- * Create anchor element corresponding to a heading element (core implementation)
- */
-const createAnchorForHeadingCore = (
-  heading: HTMLHeadingElement,
-  anchorMap: Map<string, HTMLAnchorElement>,
-  anchorTemplate: HTMLAnchorElement,
-  options: Required<MokujiOption>,
-  textToAnchorMap?: Map<string, HTMLAnchorElement>,
-): HTMLAnchorElement | undefined => {
-  const headingId = heading.id;
-  const matchedTocAnchor = findMatchingAnchorCore(anchorMap, headingId, heading.textContent || '', textToAnchorMap);
-
-  if (!matchedTocAnchor) {
-    return undefined;
-  }
-
-  const anchorElement = anchorTemplate.cloneNode(false) as HTMLAnchorElement;
-  anchorElement.href = matchedTocAnchor.hash;
-  anchorElement.textContent = options.anchorLinkSymbol;
-
-  return anchorElement;
-};
-
-/**
- * Create anchor element corresponding to a heading element
- */
-export const createAnchorForHeading = (
-  heading: HTMLHeadingElement,
-  anchorMap: Map<string, HTMLAnchorElement>,
-  anchorTemplate: HTMLAnchorElement,
-  options: Required<MokujiOption>,
-): HTMLAnchorElement | undefined => {
-  return createAnchorForHeadingCore(heading, anchorMap, anchorTemplate, options);
-};
-
-/**
- * Remove existing table of contents anchors from headings to prevent duplicate insertion
- */
 const removeExistingAnchors = (heading: HTMLHeadingElement): void => {
-  const existingAnchors = heading.querySelectorAll(`[${ANCHOR_DATASET_ATTRIBUTE}]`);
-  removeAllElements(existingAnchors);
+  const existing = heading.querySelectorAll(`[${ANCHOR_DATASET_ATTRIBUTE}]`);
+  removeAllElements(existing);
 };
 
-/**
- * Insert anchor element at specified position within heading element
- */
 const placeAnchorInHeading = (
   heading: HTMLHeadingElement,
   anchor: HTMLAnchorElement,
-  position: AnchorLinkPosition = 'before',
+  position: AnchorLinkPosition,
 ): void => {
   if (position === 'before') {
     heading.insertBefore(anchor, heading.firstChild);
@@ -200,51 +28,21 @@ const placeAnchorInHeading = (
   }
 };
 
-/**
- * Add anchor links to heading elements (core implementation)
- */
-const insertAnchorsIntoHeadingsCore = (
-  headings: HTMLHeadingElement[],
-  anchorMap: Map<string, HTMLAnchorElement>,
+export const insertPerHeadingAnchors = (
+  resolved: ReadonlyArray<ResolvedHeading>,
   options: Required<MokujiOption>,
-  textToAnchorMap?: Map<string, HTMLAnchorElement>,
-): HTMLAnchorElement[] => {
-  const anchorTemplate = createAnchorElement(options);
-  const insertedAnchors: HTMLAnchorElement[] = [];
+): ReadonlyArray<HTMLAnchorElement> => {
+  const template = createAnchorTemplate(options.anchorLinkClassName);
+  const inserted: HTMLAnchorElement[] = [];
 
-  for (const heading of headings) {
-    removeExistingAnchors(heading);
-    const anchor = createAnchorForHeadingCore(heading, anchorMap, anchorTemplate, options, textToAnchorMap);
-    if (!anchor) continue;
-
-    placeAnchorInHeading(heading, anchor, options.anchorLinkPosition);
-    insertedAnchors.push(anchor);
+  for (const r of resolved) {
+    removeExistingAnchors(r.heading);
+    const anchor = template.cloneNode(false) as HTMLAnchorElement;
+    anchor.href = `#${r.identity}`;
+    anchor.textContent = options.anchorLinkSymbol;
+    placeAnchorInHeading(r.heading, anchor, options.anchorLinkPosition);
+    inserted.push(anchor);
   }
 
-  return insertedAnchors;
-};
-
-/**
- * Add anchor links to heading elements
- * @returns Array of inserted anchor elements
- */
-export const insertAnchorsIntoHeadings = (
-  headings: HTMLHeadingElement[],
-  anchorMap: Map<string, HTMLAnchorElement>,
-  options: Required<MokujiOption>,
-): HTMLAnchorElement[] => {
-  return insertAnchorsIntoHeadingsCore(headings, anchorMap, options);
-};
-
-/**
- * Add anchor links to heading elements using maps
- * @returns Array of inserted anchor elements
- */
-export const insertAnchorsIntoHeadingsWithMaps = (
-  headings: HTMLHeadingElement[],
-  anchorMap: Map<string, HTMLAnchorElement>,
-  textToAnchorMap: Map<string, HTMLAnchorElement>,
-  options: Required<MokujiOption>,
-): HTMLAnchorElement[] => {
-  return insertAnchorsIntoHeadingsCore(headings, anchorMap, options, textToAnchorMap);
+  return inserted;
 };

--- a/src/heading-identity.test.ts
+++ b/src/heading-identity.test.ts
@@ -104,6 +104,14 @@ describe('resolveHeadingIdentities', () => {
     expect(r.identity).toBe('heading%20one');
   });
 
+  it('preserves the encoded original and uses a decoded-form base when percent-encoded ids collide', () => {
+    const h1 = createHeading(2, 'A', 'heading%20one');
+    const h2 = createHeading(2, 'B', 'heading%20one');
+    const resolved = resolveHeadingIdentities([h1, h2], { anchorType: false });
+    expect(resolved[0].identity).toBe('heading%20one');
+    expect(resolved[1].identity).toBe('heading one_1');
+  });
+
   it('keeps an invalid percent-encoded id as-is without throwing', () => {
     const h = createHeading(2, 'Invalid', 'heading%2');
     const [r] = resolveHeadingIdentities([h], { anchorType: false });

--- a/src/heading-identity.test.ts
+++ b/src/heading-identity.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { resolveHeadingIdentities, commitHeadingIdentities, type ResolvedHeading } from './heading-identity';
+
+const createHeading = (level: number, text?: string, id?: string): HTMLHeadingElement => {
+  const heading = document.createElement(`h${level}`) as HTMLHeadingElement;
+  if (text !== undefined) heading.textContent = text;
+  if (id !== undefined) heading.setAttribute('id', id);
+  return heading;
+};
+
+describe('resolveHeadingIdentities', () => {
+  it('preserves a trimmed pre-existing id', () => {
+    const h = createHeading(2, 'Existing', '  pre-existing-id  ');
+    const [r] = resolveHeadingIdentities([h], { anchorType: true });
+    expect(r.identity).toBe('pre-existing-id');
+    expect(r.level).toBe(2);
+    expect(r.heading).toBe(h);
+  });
+
+  it('does not mutate heading.id (pure)', () => {
+    const h = createHeading(2, 'Test');
+    const beforeId = h.id;
+    resolveHeadingIdentities([h], { anchorType: false });
+    expect(h.id).toBe(beforeId);
+  });
+
+  it('derives RFC 3986 encoded identity from text when no id present', () => {
+    const h = createHeading(3, 'Generated Heading');
+    const [r] = resolveHeadingIdentities([h], { anchorType: false });
+    expect(r.identity).toBe('Generated%20Heading');
+  });
+
+  it('derives Wikipedia-style identity from text when anchorType is true', () => {
+    const h = createHeading(2, 'Hello World');
+    const [r] = resolveHeadingIdentities([h], { anchorType: true });
+    expect(r.identity).toBe('Hello_World');
+  });
+
+  it('encodes Japanese text in Wikipedia style with dot replacement', () => {
+    const h = createHeading(2, '日本語');
+    const [r] = resolveHeadingIdentities([h], { anchorType: true });
+    expect(r.identity).toBe('.E6.97.A5.E6.9C.AC.E8.AA.9E');
+  });
+
+  it('encodes Japanese text in RFC 3986 style', () => {
+    const h = createHeading(2, '日本語');
+    const [r] = resolveHeadingIdentities([h], { anchorType: false });
+    expect(r.identity).toBe('%E6%97%A5%E6%9C%AC%E8%AA%9E');
+  });
+
+  it('strips colons from text in Wikipedia style', () => {
+    const h = createHeading(2, 'foo:bar baz');
+    const [r] = resolveHeadingIdentities([h], { anchorType: true });
+    expect(r.identity).toBe('foobar_baz');
+  });
+
+  it('falls back to mokuji-heading-${i} for empty text without id', () => {
+    const h1 = createHeading(2, '');
+    const h2 = createHeading(3, '');
+    const resolved = resolveHeadingIdentities([h1, h2], { anchorType: false });
+    expect(resolved[0].identity).toBe('mokuji-heading-0');
+    expect(resolved[1].identity).toBe('mokuji-heading-1');
+    expect(resolved[0].level).toBe(2);
+    expect(resolved[1].level).toBe(3);
+  });
+
+  it('dedupes simple duplicates with _N suffix in document order', () => {
+    const h1 = createHeading(2, 'Section', 'section');
+    const h2 = createHeading(2, 'Section', 'section');
+    const h3 = createHeading(2, 'Section', 'section');
+    const resolved = resolveHeadingIdentities([h1, h2, h3], { anchorType: false });
+    expect(resolved.map((r) => r.identity)).toEqual(['section', 'section_1', 'section_2']);
+  });
+
+  it('reserves pre-existing aaa_N identifiers and skips them during suffix assignment', () => {
+    const h1 = createHeading(2, 'aaa', 'aaa');
+    const h2 = createHeading(2, 'aaa', 'aaa');
+    const h3 = createHeading(2, 'aaa', 'aaa');
+    const h4 = createHeading(2, 'aaa_2', 'aaa_2');
+    const resolved = resolveHeadingIdentities([h1, h2, h3, h4], { anchorType: false });
+    expect(resolved.map((r) => r.identity)).toEqual(['aaa', 'aaa_1', 'aaa_3', 'aaa_2']);
+  });
+
+  it('preserves originals when they appear in different orders', () => {
+    const h1 = createHeading(2, 'aaa_2', 'aaa_2');
+    const h2 = createHeading(2, 'aaa', 'aaa');
+    const h3 = createHeading(2, 'aaa', 'aaa');
+    const resolved = resolveHeadingIdentities([h1, h2, h3], { anchorType: false });
+    expect(resolved.map((r) => r.identity)).toEqual(['aaa_2', 'aaa', 'aaa_1']);
+  });
+
+  it('handles multiple originals with same text and reserved suffix', () => {
+    const h4 = createHeading(2, 'aaa', 'aaa');
+    const h5 = createHeading(2, 'aaa_2', 'aaa_2');
+    const h6 = createHeading(2, 'aaa', 'aaa');
+    const h7 = createHeading(2, 'aaa_2', 'aaa_2');
+    const resolved = resolveHeadingIdentities([h4, h5, h6, h7], { anchorType: false });
+    expect(resolved.map((r) => r.identity)).toEqual(['aaa', 'aaa_2', 'aaa_1', 'aaa_3']);
+  });
+
+  it('keeps a valid percent-encoded id stable', () => {
+    const h = createHeading(2, 'Encoded', 'heading%20one');
+    const [r] = resolveHeadingIdentities([h], { anchorType: false });
+    expect(r.identity).toBe('heading%20one');
+  });
+
+  it('keeps an invalid percent-encoded id as-is without throwing', () => {
+    const h = createHeading(2, 'Invalid', 'heading%2');
+    const [r] = resolveHeadingIdentities([h], { anchorType: false });
+    expect(r.identity).toBe('heading%2');
+  });
+
+  it('returns an empty array when no headings are provided', () => {
+    expect(resolveHeadingIdentities([], { anchorType: false })).toEqual([]);
+  });
+});
+
+describe('commitHeadingIdentities', () => {
+  it('writes resolved.identity to each heading.id', () => {
+    const h = createHeading(2, 'Test');
+    const resolved: ResolvedHeading[] = [{ heading: h, identity: 'computed-id', level: 2 }];
+    commitHeadingIdentities(resolved);
+    expect(h.id).toBe('computed-id');
+  });
+
+  it('is idempotent on repeated calls', () => {
+    const h = createHeading(2, 'Test');
+    const resolved: ResolvedHeading[] = [{ heading: h, identity: 'computed-id', level: 2 }];
+    commitHeadingIdentities(resolved);
+    commitHeadingIdentities(resolved);
+    expect(h.id).toBe('computed-id');
+  });
+
+  it('overwrites a previously committed identity', () => {
+    const h = createHeading(2, 'Test');
+    h.id = 'stale';
+    const resolved: ResolvedHeading[] = [{ heading: h, identity: 'fresh', level: 2 }];
+    commitHeadingIdentities(resolved);
+    expect(h.id).toBe('fresh');
+  });
+});

--- a/src/heading-identity.ts
+++ b/src/heading-identity.ts
@@ -1,0 +1,117 @@
+import { getHeadingLevel } from './heading';
+import type { HeadingLevel } from './types';
+
+const WHITESPACE_PATTERN = /\s+/g;
+const COLON_CHARACTER = ':';
+const PERCENT_ENCODING_PATTERN = /%+/g;
+const DOT_REPLACEMENT = '.';
+
+const VALID_PERCENT_ENCODING = /%[0-9A-F]{2}/i;
+const INVALID_PERCENT_PATTERN = /%[^0-9A-F]|%[0-9A-F][^0-9A-F]|%$/i;
+
+const HEADING_DUPLICATE_SUFFIX_PATTERN = /_\d+$/;
+
+export type ResolvedHeading = {
+  readonly heading: HTMLHeadingElement;
+  readonly identity: string;
+  readonly level: HeadingLevel;
+};
+
+const replaceSpacesWithUnderscores = (text: string): string => {
+  return text.replaceAll(WHITESPACE_PATTERN, '_').replace(COLON_CHARACTER, '');
+};
+
+const convertToWikipediaStyleAnchor = (anchor: string): string => {
+  return encodeURIComponent(anchor).replaceAll(PERCENT_ENCODING_PATTERN, DOT_REPLACEMENT);
+};
+
+const generateAnchorText = (baseId: string, isWikipediaStyle: boolean): string => {
+  if (isWikipediaStyle) {
+    const anchor = replaceSpacesWithUnderscores(baseId);
+    return convertToWikipediaStyleAnchor(anchor);
+  }
+  return encodeURIComponent(baseId.trim());
+};
+
+const safeDecodeURIComponent = (encoded: string): string => {
+  if (!VALID_PERCENT_ENCODING.test(encoded)) return encoded;
+  if (INVALID_PERCENT_PATTERN.test(encoded)) return encoded;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
+};
+
+const computeInitialIdentity = (heading: HTMLHeadingElement, isWikipediaStyle: boolean): string => {
+  const existingId = heading.getAttribute('id')?.trim();
+  if (existingId) return existingId;
+  const text = (heading.textContent ?? '').trim();
+  return text ? generateAnchorText(text, isWikipediaStyle) : '';
+};
+
+/**
+ * Resolve the final unique identity for each heading in document order.
+ * Pure — use `commitHeadingIdentities` to commit to the DOM.
+ *
+ * Two passes are required: pass 1 collects every initial identity into
+ * `reserved` so that pass 2 can skip pre-existing `${base}_N`-shaped ids when
+ * suffixing collisions (e.g. an author-set `aaa_2` reserves the slot before
+ * an earlier duplicate `aaa` would otherwise claim it).
+ */
+export const resolveHeadingIdentities = (
+  headings: ReadonlyArray<HTMLHeadingElement>,
+  options: { anchorType: boolean },
+): ReadonlyArray<ResolvedHeading> => {
+  const initials: { encoded: string; decoded: string }[] = [];
+  const reserved = new Set<string>();
+
+  for (const [i, heading] of headings.entries()) {
+    const computed = computeInitialIdentity(heading, options.anchorType);
+    const encoded = computed || `mokuji-heading-${i}`;
+    const decoded = safeDecodeURIComponent(encoded);
+    initials.push({ encoded, decoded });
+    reserved.add(decoded);
+  }
+
+  const resolved: ResolvedHeading[] = [];
+  const used = new Set<string>();
+  const counters = new Map<string, number>();
+
+  for (const [i, heading] of headings.entries()) {
+    const { encoded: initial, decoded } = initials[i];
+
+    let identity: string;
+    if (used.has(decoded)) {
+      const baseId = decoded.replace(HEADING_DUPLICATE_SUFFIX_PATTERN, '') || decoded;
+      let counter = (counters.get(baseId) ?? 0) + 1;
+      while (used.has(`${baseId}_${counter}`) || reserved.has(`${baseId}_${counter}`)) {
+        counter++;
+      }
+      identity = `${baseId}_${counter}`;
+      counters.set(baseId, counter);
+      used.add(identity);
+    } else {
+      identity = initial;
+      used.add(decoded);
+    }
+
+    resolved.push({
+      heading,
+      identity,
+      level: getHeadingLevel(heading),
+    });
+  }
+
+  return resolved;
+};
+
+/**
+ * Commit each resolved identity to its heading element. Idempotent.
+ * The only DOM-mutating step in the identity pipeline.
+ */
+export const commitHeadingIdentities = (resolved: ReadonlyArray<ResolvedHeading>): void => {
+  for (const r of resolved) {
+    r.heading.id = r.identity;
+  }
+};

--- a/src/heading.test.ts
+++ b/src/heading.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { assignInitialIdToHeading, ensureUniqueHeadingIds, getFilteredHeadings, getHeadingLevel } from './heading';
+import { getFilteredHeadings, getHeadingLevel } from './heading';
 
 const createHeading = (level: number, text?: string): HTMLHeadingElement => {
   const heading = document.createElement(`h${level}`) as HTMLHeadingElement;
-  if (text) {
-    heading.textContent = text;
-  }
+  if (text) heading.textContent = text;
   return heading;
 };
 
@@ -21,52 +19,17 @@ describe('heading', () => {
     container.remove();
   });
 
-  // ========================================
-  // Heading ID Management Tests
-  // ========================================
-
-  describe('assignInitialIdToHeading', () => {
-    it('retains and normalizes an existing id so anchors stay stable', () => {
-      const heading = createHeading(2, 'Existing');
-      heading.setAttribute('id', '  pre-existing-id  ');
-
-      const assignedId = assignInitialIdToHeading(heading, true);
-
-      expect(assignedId).toBe('pre-existing-id');
-      expect(heading.id).toBe('pre-existing-id');
-    });
-
-    it('derives an id from text content when none is provided', () => {
-      const heading = createHeading(3, 'Generated Heading');
-
-      const assignedId = assignInitialIdToHeading(heading, false);
-
-      expect(assignedId).toBe('Generated%20Heading');
-      expect(heading.id).toBe('Generated%20Heading');
-    });
-  });
-
-  // ========================================
-  // Heading Level Tests
-  // ========================================
-
   describe('getHeadingLevel', () => {
     it('extracts the numeric level for standard heading elements', () => {
       const heading = createHeading(4, 'Heading');
-
       expect(getHeadingLevel(heading)).toBe(4);
     });
 
     it('falls back to level 6 for unexpected tag names', () => {
       const invalidHeading = document.createElement('h7') as HTMLHeadingElement;
-
       expect(getHeadingLevel(invalidHeading)).toBe(6);
     });
   });
-
-  // ========================================
-  // Heading Filtering Tests
-  // ========================================
 
   describe('getFilteredHeadings', () => {
     it('returns headings within the requested level range, preserving their order', () => {
@@ -134,172 +97,6 @@ describe('heading', () => {
       const filtered = getFilteredHeadings(container, 1, 6);
 
       expect(filtered.map((h) => h.textContent)).toEqual(['Top', 'Bottom']);
-    });
-  });
-
-  // ========================================
-  // Heading ID Uniqueness Tests
-  // ========================================
-
-  describe('ensureUniqueHeadingIds', () => {
-    it('deduplicates conflicting ids and updates matching anchors to keep navigation working', () => {
-      const headingOne = createHeading(2, 'Section');
-      headingOne.id = 'section';
-      const headingTwo = createHeading(2, 'Section');
-      headingTwo.id = 'section';
-      const headingThree = createHeading(2, 'Section');
-      headingThree.id = 'section';
-
-      const anchorOne = document.createElement('a');
-      anchorOne.href = '#section';
-      const anchorTwo = document.createElement('a');
-      anchorTwo.href = '#section';
-      const anchorThree = document.createElement('a');
-      anchorThree.href = '#section';
-
-      ensureUniqueHeadingIds([headingOne, headingTwo, headingThree], [anchorOne, anchorTwo, anchorThree]);
-
-      expect(headingOne.id).toBe('section');
-      expect(headingTwo.id).toBe('section_1');
-      expect(headingThree.id).toBe('section_2');
-      expect(anchorOne.href.endsWith('#section')).toBe(true);
-      expect(anchorTwo.href.endsWith('#section_1')).toBe(true);
-      expect(anchorThree.href.endsWith('#section_2')).toBe(true);
-    });
-
-    it('creates fallback ids for headings without existing identifiers', () => {
-      const headingOne = createHeading(2, '');
-      headingOne.id = '';
-      const headingTwo = createHeading(3, '');
-      headingTwo.id = '';
-
-      const anchorOne = document.createElement('a');
-      const anchorTwo = document.createElement('a');
-
-      ensureUniqueHeadingIds([headingOne, headingTwo], [anchorOne, anchorTwo]);
-
-      expect(headingOne.id).toBe('mokuji-heading-0');
-      expect(headingTwo.id).toBe('mokuji-heading-1');
-      expect(anchorOne.href.endsWith('#mokuji-heading-0')).toBe(true);
-      expect(anchorTwo.href.endsWith('#mokuji-heading-1')).toBe(true);
-    });
-
-    it('handles percent-encoded ids by decoding only when safe', () => {
-      const encoded = createHeading(2, 'Encoded');
-      encoded.id = 'heading%20one';
-      const invalid = createHeading(2, 'Invalid');
-      invalid.id = 'heading%2';
-
-      const anchorForEncoded = document.createElement('a');
-      anchorForEncoded.href = '#heading%20one';
-      const anchorForInvalid = document.createElement('a');
-      anchorForInvalid.href = '#heading%2';
-
-      ensureUniqueHeadingIds([encoded, invalid], [anchorForEncoded, anchorForInvalid]);
-
-      expect(encoded.id).toBe('heading%20one');
-      expect(anchorForEncoded.href.endsWith('#heading%20one')).toBe(true);
-      expect(invalid.id).toBe('heading%2');
-      expect(anchorForInvalid.href.endsWith('#heading%2')).toBe(true);
-    });
-
-    it('ignores missing anchors without throwing and still ensures unique ids', () => {
-      const headingOne = createHeading(2, 'Section');
-      headingOne.id = 'section';
-      const headingTwo = createHeading(2, 'Section');
-      headingTwo.id = 'section';
-
-      ensureUniqueHeadingIds([headingOne, headingTwo], [document.createElement('a')]);
-
-      expect(headingOne.id).toBe('section');
-      expect(headingTwo.id).toBe('section_1');
-    });
-
-    it('should preserve original IDs like "aaa_2" when handling duplicates', () => {
-      const heading1 = document.createElement('h2');
-      heading1.textContent = 'aaa';
-      heading1.id = 'aaa';
-
-      const heading2 = document.createElement('h2');
-      heading2.textContent = 'aaa';
-      heading2.id = 'aaa';
-
-      const heading3 = document.createElement('h2');
-      heading3.textContent = 'aaa';
-      heading3.id = 'aaa';
-
-      const heading4 = document.createElement('h2');
-      heading4.textContent = 'aaa_2';
-      heading4.id = 'aaa_2';
-
-      const anchors = [
-        document.createElement('a'),
-        document.createElement('a'),
-        document.createElement('a'),
-        document.createElement('a'),
-      ];
-
-      ensureUniqueHeadingIds([heading1, heading2, heading3, heading4], anchors);
-
-      // The expected behavior: preserve original "aaa_2" and adjust others
-      expect(heading1.id).toBe('aaa');
-      expect(heading2.id).toBe('aaa_1');
-      expect(heading3.id).toBe('aaa_3'); // Skip aaa_2 since it's reserved for the original
-      expect(heading4.id).toBe('aaa_2'); // Original aaa_2 should be preserved as is
-    });
-
-    it('should handle complex cases where original IDs appear in different orders', () => {
-      // Case 1: Original ID appears first
-      const h1 = document.createElement('h2');
-      h1.textContent = 'aaa_2';
-      h1.id = 'aaa_2';
-
-      const h2 = document.createElement('h2');
-      h2.textContent = 'aaa';
-      h2.id = 'aaa';
-
-      const h3 = document.createElement('h2');
-      h3.textContent = 'aaa';
-      h3.id = 'aaa';
-
-      const anchors1 = [document.createElement('a'), document.createElement('a'), document.createElement('a')];
-
-      ensureUniqueHeadingIds([h1, h2, h3], anchors1);
-
-      expect(h1.id).toBe('aaa_2'); // Original preserved
-      expect(h2.id).toBe('aaa'); // First aaa gets base
-      expect(h3.id).toBe('aaa_1'); // Second aaa gets _1
-
-      // Case 2: Multiple original IDs with same text
-      const h4 = document.createElement('h2');
-      h4.textContent = 'aaa';
-      h4.id = 'aaa';
-
-      const h5 = document.createElement('h2');
-      h5.textContent = 'aaa_2';
-      h5.id = 'aaa_2';
-
-      const h6 = document.createElement('h2');
-      h6.textContent = 'aaa';
-      h6.id = 'aaa';
-
-      const h7 = document.createElement('h2');
-      h7.textContent = 'aaa_2';
-      h7.id = 'aaa_2';
-
-      const anchors2 = [
-        document.createElement('a'),
-        document.createElement('a'),
-        document.createElement('a'),
-        document.createElement('a'),
-      ];
-
-      ensureUniqueHeadingIds([h4, h5, h6, h7], anchors2);
-
-      expect(h4.id).toBe('aaa'); // First aaa
-      expect(h5.id).toBe('aaa_2'); // First aaa_2 preserved
-      expect(h6.id).toBe('aaa_1'); // Second aaa gets _1
-      expect(h7.id).toBe('aaa_3'); // Second aaa_2 gets _3 (skip _2 since it's taken)
     });
   });
 });

--- a/src/heading.ts
+++ b/src/heading.ts
@@ -1,138 +1,12 @@
 import { getAllHeadingElements } from './utils/dom';
 import type { HeadingLevel } from './types';
 
-/**
- * Regular expressions and symbols used for text processing and anchor text generation
- */
-const WHITESPACE_PATTERN = /\s+/g;
-const COLON_CHARACTER = ':';
-const PERCENT_ENCODING_PATTERN = /%+/g;
-const DOT_REPLACEMENT = '.';
-
-/**
- * Regular expressions for checking the validity of URL-encoded strings
- */
-const VALID_PERCENT_ENCODING = /%[0-9A-F]{2}/i;
-const INVALID_PERCENT_PATTERN = /%[^0-9A-F]|%[0-9A-F][^0-9A-F]|%$/i;
-
-const HEADING_DUPLICATE_SUFFIX_PATTERN = /_\d+$/;
-
 const MIN_HEADING_LEVEL: HeadingLevel = 1;
 const MAX_HEADING_LEVEL: HeadingLevel = 6;
 const FALLBACK_HEADING_LEVEL = MAX_HEADING_LEVEL;
 
 /**
- * Replace spaces with underscores and remove colons in text
- */
-const replaceSpacesWithUnderscores = (text: string): string => {
-  return text.replaceAll(WHITESPACE_PATTERN, '_').replace(COLON_CHARACTER, '');
-};
-
-/**
- * Convert text to Wikipedia-style anchor format
- */
-const convertToWikipediaStyleAnchor = (anchor: string): string => {
-  return encodeURIComponent(anchor).replaceAll(PERCENT_ENCODING_PATTERN, DOT_REPLACEMENT);
-};
-
-/**
- * Generate anchor text
- */
-export const generateAnchorText = (baseId: string, isConvertToWikipediaStyleAnchor: boolean): string => {
-  if (isConvertToWikipediaStyleAnchor) {
-    const anchorText = replaceSpacesWithUnderscores(baseId);
-    return convertToWikipediaStyleAnchor(anchorText);
-  }
-
-  return encodeURIComponent(baseId.trim());
-};
-
-/**
- * Safely decode URI component
- */
-const safeDecodeURIComponent = (encoded: string): string => {
-  if (!VALID_PERCENT_ENCODING.test(encoded)) {
-    return encoded;
-  }
-
-  if (INVALID_PERCENT_PATTERN.test(encoded)) {
-    return encoded;
-  }
-
-  try {
-    return decodeURIComponent(encoded);
-  } catch {
-    return encoded;
-  }
-};
-
-/**
- * Assign ID to heading element
- */
-export const assignInitialIdToHeading = (
-  heading: HTMLHeadingElement,
-  isConvertToWikipediaStyleAnchor: boolean,
-): string => {
-  const existingId = heading.getAttribute('id')?.trim();
-  if (existingId) {
-    heading.id = existingId;
-    return existingId;
-  }
-
-  const baseHeadingId = (heading.textContent || '').trim();
-  const anchorText = generateAnchorText(baseHeadingId, isConvertToWikipediaStyleAnchor);
-  heading.id = anchorText;
-  return anchorText;
-};
-
-/**
- * Resolve duplicate heading IDs and update anchors
- */
-export const ensureUniqueHeadingIds = (headings: HTMLHeadingElement[], anchors: HTMLAnchorElement[]) => {
-  const usedIds = new Set<string>();
-  const idCounts = new Map<string, number>();
-  const originalIds = new Set<string>();
-
-  for (const [i, heading] of headings.entries()) {
-    const originalId = heading.id || `mokuji-heading-${i}`;
-    originalIds.add(safeDecodeURIComponent(originalId));
-  }
-
-  for (const [i, heading] of headings.entries()) {
-    const anchor = anchors[i];
-    const originalId = heading.id || `mokuji-heading-${i}`;
-    const decodedId = safeDecodeURIComponent(originalId);
-
-    if (!usedIds.has(decodedId)) {
-      heading.id = originalId;
-      usedIds.add(decodedId);
-
-      if (anchor) {
-        anchor.href = `#${originalId}`;
-      }
-      continue;
-    }
-
-    const baseId = decodedId.replace(HEADING_DUPLICATE_SUFFIX_PATTERN, '') || decodedId;
-    let counter = (idCounts.get(baseId) || 0) + 1;
-
-    while (usedIds.has(`${baseId}_${counter}`) || originalIds.has(`${baseId}_${counter}`)) {
-      counter++;
-    }
-
-    const candidateId = `${baseId}_${counter}`;
-    idCounts.set(baseId, counter);
-    heading.id = candidateId;
-    usedIds.add(candidateId);
-
-    if (anchor) {
-      anchor.href = `#${candidateId}`;
-    }
-  }
-};
-
-/**
- * Get heading element level as a numeric value
+ * Get heading element level as a numeric value.
  */
 export const getHeadingLevel = (heading: HTMLHeadingElement): HeadingLevel => {
   const numericLevel = Number.parseInt(heading.tagName.slice(1), 10);
@@ -143,7 +17,7 @@ export const getHeadingLevel = (heading: HTMLHeadingElement): HeadingLevel => {
 };
 
 /**
- * Get heading elements within the specified level range
+ * Get heading elements within the specified level range.
  */
 export const getFilteredHeadings = (
   element: Element,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { createElement } from './utils/dom';
 import type { MokujiOption, HeadingLevel } from './types';
-import { getFilteredHeadings, ensureUniqueHeadingIds } from './heading';
-import { createAnchorMap, createTextToAnchorMap, insertAnchorsIntoHeadingsWithMaps } from './anchor';
-import { buildMokujiHierarchy } from './mokuji-core';
+import { getFilteredHeadings } from './heading';
+import { resolveHeadingIdentities, commitHeadingIdentities } from './heading-identity';
+import { buildTocList } from './mokuji-core';
+import { insertPerHeadingAnchors } from './anchor';
 import { MOKUJI_LIST_DATASET_ATTRIBUTE, defaultOptions } from './utils/constants';
 
 export type MokujiResult<T extends HTMLElement = HTMLElement> = {
@@ -13,23 +13,15 @@ export type MokujiResult<T extends HTMLElement = HTMLElement> = {
 
 export { MokujiOption, HeadingLevel };
 
-/**
- * Process option settings, merge with default values, and restrict to valid range
- */
 const processOptions = (externalOptions?: MokujiOption): Required<MokujiOption> => {
-  const merged = {
-    ...defaultOptions,
-    ...externalOptions,
-  };
-
+  const merged = { ...defaultOptions, ...externalOptions };
   const minLevel = Math.max(1, Math.min(merged.minLevel, 6)) as HeadingLevel;
   const maxLevel = Math.max(minLevel, Math.min(merged.maxLevel, 6)) as HeadingLevel;
-
   return { ...merged, minLevel, maxLevel };
 };
 
 /**
- * Generate table of contents from headings within the given element (public API)
+ * Generate a table of contents from headings within the given element.
  */
 export const Mokuji = <T extends HTMLElement>(
   element: T | undefined,
@@ -41,43 +33,22 @@ export const Mokuji = <T extends HTMLElement>(
   }
 
   const options = processOptions(externalOptions);
+  const { minLevel, maxLevel, includeBlockquoteHeadings, anchorType } = options;
+  const headings = getFilteredHeadings(element, minLevel, maxLevel, { includeBlockquoteHeadings });
+  if (headings.length === 0) return undefined;
 
-  const { minLevel, maxLevel, includeBlockquoteHeadings } = options;
-  const filteredHeadings = getFilteredHeadings(element, minLevel, maxLevel, { includeBlockquoteHeadings });
+  const resolved = resolveHeadingIdentities(headings, { anchorType });
+  commitHeadingIdentities(resolved);
 
-  if (filteredHeadings.length === 0) {
-    return undefined;
-  }
+  const list = buildTocList(resolved, options.anchorContainerTagName);
+  list.setAttribute(MOKUJI_LIST_DATASET_ATTRIBUTE, '');
 
-  const listContainer = createElement(options.anchorContainerTagName);
-  listContainer.setAttribute(MOKUJI_LIST_DATASET_ATTRIBUTE, '');
-
-  buildMokujiHierarchy(filteredHeadings, listContainer, options.anchorType);
-
-  const anchors = [...listContainer.querySelectorAll('a')];
-
-  if (anchors.length === 0) {
-    return undefined;
-  }
-
-  ensureUniqueHeadingIds(filteredHeadings, anchors);
-
-  const insertedAnchors = options.anchorLink
-    ? insertAnchorsIntoHeadingsWithMaps(
-        filteredHeadings,
-        createAnchorMap(anchors),
-        createTextToAnchorMap(anchors),
-        options,
-      )
-    : [];
+  const insertedAnchors = options.anchorLink ? insertPerHeadingAnchors(resolved, options) : [];
 
   const destroy = () => {
-    listContainer.remove();
-
-    for (const anchor of insertedAnchors) {
-      anchor.remove();
-    }
+    list.remove();
+    for (const anchor of insertedAnchors) anchor.remove();
   };
 
-  return { element, list: listContainer, destroy };
+  return { element, list, destroy };
 };

--- a/src/mokuji-core.test.ts
+++ b/src/mokuji-core.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { buildMokujiHierarchy } from './mokuji-core';
+import { describe, it, expect } from 'vitest';
+import { buildTocList } from './mokuji-core';
+import type { ResolvedHeading } from './heading-identity';
+import type { HeadingLevel } from './types';
 
 const createHeading = (level: number, text: string): HTMLHeadingElement => {
   const heading = document.createElement(`h${level}`) as HTMLHeadingElement;
@@ -7,49 +9,36 @@ const createHeading = (level: number, text: string): HTMLHeadingElement => {
   return heading;
 };
 
-describe('buildMokujiHierarchy', () => {
-  let container: HTMLElement;
+const r = (heading: HTMLHeadingElement, identity: string, level: HeadingLevel): ResolvedHeading => ({
+  heading,
+  identity,
+  level,
+});
 
-  beforeEach(() => {
-    container = document.createElement('div');
-    document.body.append(container);
+describe('buildTocList', () => {
+  it('returns an empty list when no resolved headings are provided', () => {
+    const list = buildTocList([], 'ol');
+    expect(list.tagName).toBe('OL');
+    expect(list.children).toHaveLength(0);
   });
 
-  afterEach(() => {
-    container.remove();
-  });
-
-  it('returns an empty list when no headings are provided', () => {
-    const listContainer = document.createElement('ol');
-
-    buildMokujiHierarchy([], listContainer, false);
-
-    expect(listContainer.children).toHaveLength(0);
-  });
-
-  it('renders a single heading as a list item hyperlink', () => {
+  it('renders a single resolved heading as a list item hyperlink', () => {
     const heading = createHeading(2, 'Test Heading');
-    container.append(heading);
-    const listContainer = document.createElement('ol');
+    const list = buildTocList([r(heading, 'Test%20Heading', 2)], 'ol');
 
-    buildMokujiHierarchy([heading], listContainer, false);
-
-    const firstItem = listContainer.children[0] as HTMLLIElement;
+    const firstItem = list.children[0] as HTMLLIElement;
     expect(firstItem.tagName).toBe('LI');
     const anchor = firstItem.querySelector('a');
     expect(anchor?.textContent).toBe('Test Heading');
     expect(anchor?.getAttribute('href')).toBe('#Test%20Heading');
   });
 
-  it('renders multiple top-level headings in the order they appear', () => {
-    const headingOne = createHeading(2, 'First Heading');
-    const headingTwo = createHeading(2, 'Second Heading');
-    container.append(headingOne, headingTwo);
-    const listContainer = document.createElement('ol');
+  it('renders multiple top-level headings in document order', () => {
+    const h1 = createHeading(2, 'First Heading');
+    const h2 = createHeading(2, 'Second Heading');
+    const list = buildTocList([r(h1, 'First%20Heading', 2), r(h2, 'Second%20Heading', 2)], 'ol');
 
-    buildMokujiHierarchy([headingOne, headingTwo], listContainer, false);
-
-    const anchors = [...listContainer.querySelectorAll('a')].map((node) => ({
+    const anchors = [...list.querySelectorAll('a')].map((node) => ({
       text: node.textContent,
       href: node.getAttribute('href'),
     }));
@@ -64,61 +53,30 @@ describe('buildMokujiHierarchy', () => {
     const h1 = createHeading(1, 'Main Title');
     const h2 = createHeading(2, 'Subtitle');
     const h3 = createHeading(3, 'Subsection');
-    container.append(h1, h2, h3);
-    const listContainer = document.createElement('ol');
+    const list = buildTocList([r(h1, 'main', 1), r(h2, 'sub', 2), r(h3, 'subsub', 3)], 'ol');
 
-    buildMokujiHierarchy([h1, h2, h3], listContainer, false);
-
-    const mainItem = listContainer.children[0] as HTMLLIElement;
+    const mainItem = list.children[0] as HTMLLIElement;
     expect(mainItem.querySelector('a')?.textContent).toBe('Main Title');
 
-    const nestedList = mainItem.querySelector('ol');
-    expect(nestedList?.children).toHaveLength(1);
-    const subtitleItem = nestedList?.children[0] as HTMLLIElement;
-    expect(subtitleItem.querySelector('a')?.textContent).toBe('Subtitle');
+    const nested = mainItem.querySelector('ol');
+    expect(nested?.children).toHaveLength(1);
+    const subItem = nested?.children[0] as HTMLLIElement;
+    expect(subItem.querySelector('a')?.textContent).toBe('Subtitle');
 
-    const deeperList = subtitleItem.querySelector('ol');
-    expect(deeperList?.children).toHaveLength(1);
-    expect(deeperList?.children[0].querySelector('a')?.textContent).toBe('Subsection');
-  });
-
-  it('generates Wikipedia-style anchors when requested', () => {
-    const heading = createHeading(2, 'Sこkao16L');
-    container.append(heading);
-    const listContainer = document.createElement('ol');
-
-    buildMokujiHierarchy([heading], listContainer, true);
-
-    const anchor = listContainer.querySelector('a');
-    expect(anchor?.getAttribute('href')).toContain('.E3.81.93');
-    expect(heading.id).toContain('.E3.81.93');
-  });
-
-  it('preserves an existing heading id', () => {
-    const heading = createHeading(2, 'Test Heading');
-    heading.id = 'custom-id';
-    container.append(heading);
-    const listContainer = document.createElement('ol');
-
-    buildMokujiHierarchy([heading], listContainer, false);
-
-    const anchor = listContainer.querySelector('a');
-    expect(anchor?.getAttribute('href')).toBe('#custom-id');
-    expect(heading.id).toBe('custom-id');
+    const deeper = subItem.querySelector('ol');
+    expect(deeper?.children).toHaveLength(1);
+    expect(deeper?.children[0].querySelector('a')?.textContent).toBe('Subsection');
   });
 
   it('keeps document order even when heading levels jump', () => {
     const h1 = createHeading(1, 'Level 1');
     const h3 = createHeading(3, 'Level 3');
     const h2 = createHeading(2, 'Level 2');
-    container.append(h1, h3, h2);
-    const listContainer = document.createElement('ol');
+    const list = buildTocList([r(h1, 'l1', 1), r(h3, 'l3', 3), r(h2, 'l2', 2)], 'ol');
 
-    buildMokujiHierarchy([h1, h3, h2], listContainer, false);
-
-    const nestedList = listContainer.querySelector('ol');
-    expect(nestedList?.children).toHaveLength(2);
-    const [firstChild, secondChild] = [...(nestedList?.children ?? [])] as HTMLLIElement[];
+    const nested = list.querySelector('ol');
+    expect(nested?.children).toHaveLength(2);
+    const [firstChild, secondChild] = [...(nested?.children ?? [])] as HTMLLIElement[];
     expect(firstChild.querySelector('a')?.textContent).toBe('Level 3');
     expect(secondChild.querySelector('a')?.textContent).toBe('Level 2');
   });
@@ -126,50 +84,34 @@ describe('buildMokujiHierarchy', () => {
   it('supports list containers other than ordered lists', () => {
     const h1 = createHeading(1, 'Main');
     const h2 = createHeading(2, 'Sub');
-    container.append(h1, h2);
-    const listContainer = document.createElement('ul');
+    const list = buildTocList([r(h1, 'main', 1), r(h2, 'sub', 2)], 'ul');
 
-    buildMokujiHierarchy([h1, h2], listContainer, false);
-
-    const nestedList = listContainer.querySelector('ul');
-    expect(nestedList?.tagName).toBe('UL');
-  });
-
-  it('sanitizes anchors for headings with surrounding whitespace and symbols', () => {
-    const heading = createHeading(2, '  Test & Special: Characters  ');
-    container.append(heading);
-    const listContainer = document.createElement('ol');
-
-    buildMokujiHierarchy([heading], listContainer, false);
-
-    const anchor = listContainer.querySelector('a');
-    expect(anchor?.textContent).toBe('  Test & Special: Characters  ');
-    expect(anchor?.getAttribute('href')).toBe('#Test%20%26%20Special%3A%20Characters');
-    expect(heading.id).toBe('Test%20%26%20Special%3A%20Characters');
+    expect(list.tagName).toBe('UL');
+    expect(list.querySelector('ul')?.tagName).toBe('UL');
   });
 
   it('builds nested lists for multiple chapters and sections', () => {
-    const h1One = createHeading(1, 'Chapter 1');
-    const h2One = createHeading(2, 'Section 1.1');
-    const h3One = createHeading(3, 'Subsection 1.1.1');
-    const h3Two = createHeading(3, 'Subsection 1.1.2');
-    const h2Two = createHeading(2, 'Section 1.2');
-    const h1Two = createHeading(1, 'Chapter 2');
-    container.append(h1One, h2One, h3One, h3Two, h2Two, h1Two);
-    const listContainer = document.createElement('ol');
+    const h1a = createHeading(1, 'Chapter 1');
+    const h2a = createHeading(2, 'Section 1.1');
+    const h3a = createHeading(3, 'Subsection 1.1.1');
+    const h3b = createHeading(3, 'Subsection 1.1.2');
+    const h2b = createHeading(2, 'Section 1.2');
+    const h1b = createHeading(1, 'Chapter 2');
 
-    buildMokujiHierarchy([h1One, h2One, h3One, h3Two, h2Two, h1Two], listContainer, false);
+    const list = buildTocList(
+      [r(h1a, 'c1', 1), r(h2a, 's11', 2), r(h3a, 'ss111', 3), r(h3b, 'ss112', 3), r(h2b, 's12', 2), r(h1b, 'c2', 1)],
+      'ol',
+    );
 
-    expect(listContainer.children).toHaveLength(2);
-
-    const [chapterOneItem, chapterTwoItem] = [...listContainer.children] as HTMLLIElement[];
-    const chapterOneList = chapterOneItem.querySelector('ol');
+    expect(list.children).toHaveLength(2);
+    const [chapterOne, chapterTwo] = [...list.children] as HTMLLIElement[];
+    const chapterOneList = chapterOne.querySelector('ol');
     expect(chapterOneList?.children).toHaveLength(2);
 
-    const sectionOneItem = chapterOneList?.children[0] as HTMLLIElement;
-    const sectionOneList = sectionOneItem.querySelector('ol');
+    const sectionOne = chapterOneList?.children[0] as HTMLLIElement;
+    const sectionOneList = sectionOne.querySelector('ol');
     expect(sectionOneList?.children).toHaveLength(2);
 
-    expect(chapterTwoItem.querySelector('a')?.textContent).toBe('Chapter 2');
+    expect(chapterTwo.querySelector('a')?.textContent).toBe('Chapter 2');
   });
 });

--- a/src/mokuji-core.ts
+++ b/src/mokuji-core.ts
@@ -21,10 +21,10 @@ const buildTocHierarchy = (resolved: ReadonlyArray<ResolvedHeading>): TocItem[] 
       children: [],
     };
 
-    let topLevel = levelStack.at(-1);
+    let topLevel = levelStack.at(-1) ?? levelStack[0];
     while (levelStack.length > 1 && r.level <= topLevel.level) {
       levelStack.pop();
-      topLevel = levelStack.at(-1);
+      topLevel = levelStack.at(-1) ?? levelStack[0];
     }
 
     topLevel.items.push(newItem);

--- a/src/mokuji-core.ts
+++ b/src/mokuji-core.ts
@@ -1,55 +1,47 @@
 import { createElement } from './utils/dom';
-import { assignInitialIdToHeading, getHeadingLevel } from './heading';
+import type { ResolvedHeading } from './heading-identity';
+import type { AnchorContainerTagName } from './types';
 
 type TocItem = {
   text: string | null;
   href: string;
-  level: number;
   children: TocItem[];
 };
 
 type TableOfContentsContainer = HTMLUListElement | HTMLOListElement;
 
-/**
- * Build hierarchical data structure from headings
- */
-const buildTocHierarchy = (headings: HTMLHeadingElement[], isConvertToWikipediaStyleAnchor: boolean): TocItem[] => {
+const buildTocHierarchy = (resolved: ReadonlyArray<ResolvedHeading>): TocItem[] => {
   const rootLevelItems: TocItem[] = [];
   const levelStack: { level: number; items: TocItem[] }[] = [{ level: 0, items: rootLevelItems }];
 
-  for (const heading of headings) {
-    const currentHeadingLevel = getHeadingLevel(heading);
-    const anchorText = assignInitialIdToHeading(heading, isConvertToWikipediaStyleAnchor);
-
+  for (const r of resolved) {
     const newItem: TocItem = {
-      text: heading.textContent,
-      href: `#${anchorText}`,
-      level: currentHeadingLevel,
+      text: r.heading.textContent,
+      href: `#${r.identity}`,
       children: [],
     };
 
-    // Find appropriate parent level
-    let topLevel = levelStack.at(-1)!;
-    while (levelStack.length > 1 && currentHeadingLevel <= topLevel.level) {
+    let topLevel = levelStack.at(-1);
+    while (levelStack.length > 1 && r.level <= topLevel.level) {
       levelStack.pop();
-      topLevel = levelStack.at(-1)!;
+      topLevel = levelStack.at(-1);
     }
 
     topLevel.items.push(newItem);
-    levelStack.push({ level: currentHeadingLevel, items: newItem.children });
+    levelStack.push({ level: r.level, items: newItem.children });
   }
 
   return rootLevelItems;
 };
 
-/**
- * Generate DOM elements from TOC hierarchy
- */
-const buildTocDom = (items: TocItem[], listContainer: TableOfContentsContainer): void => {
+const buildTocDom = (
+  items: TocItem[],
+  listContainer: TableOfContentsContainer,
+  containerTag: AnchorContainerTagName,
+): void => {
   const listItemTemplate = createElement('li');
   const anchorTemplate = createElement('a');
-  const childListTagName = listContainer.tagName.toLowerCase() as 'ul' | 'ol';
-  const childListTemplate = createElement(childListTagName);
+  const childListTemplate = createElement(containerTag);
 
   const buildListRecursive = (parentListElement: HTMLElement, tocItems: TocItem[]): void => {
     for (const item of tocItems) {
@@ -72,14 +64,12 @@ const buildTocDom = (items: TocItem[], listContainer: TableOfContentsContainer):
   buildListRecursive(listContainer, items);
 };
 
-/**
- * Generate hierarchical table of contents data structure from heading elements and build DOM
- */
-export const buildMokujiHierarchy = (
-  headings: HTMLHeadingElement[],
-  listContainer: TableOfContentsContainer,
-  isConvertToWikipediaStyleAnchor: boolean,
-): void => {
-  const tocItems = buildTocHierarchy(headings, isConvertToWikipediaStyleAnchor);
-  buildTocDom(tocItems, listContainer);
+export const buildTocList = (
+  resolved: ReadonlyArray<ResolvedHeading>,
+  containerTag: AnchorContainerTagName,
+): TableOfContentsContainer => {
+  const container = createElement(containerTag);
+  const tocItems = buildTocHierarchy(resolved);
+  buildTocDom(tocItems, container, containerTag);
+  return container;
 };


### PR DESCRIPTION
## Summary

Refactor mokuji.js so each heading's final unique ID (the **heading identity**) is resolved in one phase before any DOM is built. Downstream consumers (TOC list, per-heading anchors) derive `href` directly from `ResolvedHeading.identity`, eliminating the multi-strategy anchor matcher and the encoded/decoded reconciliation that arose from the prior interleaved two-phase approach.

Net: -730 lines, public `Mokuji()` API unchanged, 58 passing tests (was 57).

## Changes

**New**
- `src/heading-identity.ts` — pure `resolveHeadingIdentities()` + DOM-mutating `commitHeadingIdentities()`; consolidates encoding, `_N`-suffix dedup, and `${base}_N` reservation rules.
- `src/heading-identity.test.ts` — covers encoding, dedup, reservation, and percent-encoded duplicate edge cases.
- `CONTEXT.md` — domain vocabulary (`heading identity`, `resolved heading`, `TOC list anchor`, `per-heading anchor`).

**Slimmed**
- `src/heading.ts` — ID/encoding logic moved out, keeps only `getFilteredHeadings` + `getHeadingLevel`.
- `src/anchor.ts` — single public function `insertPerHeadingAnchors`. Removed map-based lookup machinery, the 3-level fallback (`findAnchorById*`, `findAnchorByText`), and the `*Core` indirection. `href = '#' + identity`.

**Reshaped**
- `src/mokuji-core.ts` — `buildTocList(resolved, tag)` consumes `ResolvedHeading[]`, returns the list element. Dropped dead `TocItem.level` field.
- `src/index.ts` — pipeline reads as filter → resolve → commit → build → (optional) insert anchors.

**Sandbox**
- `__sandbox__/src/App.tsx` — consolidated dual `useEffect` (was creating TOC twice on mount), removed derived-state-via-effect ref pattern, extracted `destroyMokuji`, fixed self-assign `innerHTML` bug that orphaned anchor references and broke `destroy()` cleanup of per-heading anchors.

**Docs**
- `.github/copilot-instructions.md` — updated Module Structure, Core Patterns; removed obsolete "DRY Pattern with Core Suffix" section.

## Test plan

- [x] `npm run test` — 58/58 passing
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — no project errors
- [x] Public API behavior preserved (`index.test.ts` unchanged)
- [x] `aaa_2` reservation cases ported as-is
- [x] Sandbox manually verified: create/destroy/options work without leaks