### PR TITLE
feat: add scrollSpy option for active heading tracking

### DIFF
--- a/__sandbox__/src/App.css
+++ b/__sandbox__/src/App.css
@@ -13,3 +13,31 @@ hr {
   height: 2px;
   margin: 1.5rem 0;
 }
+
+.grid > div:first-child {
+  position: sticky;
+  top: 1rem;
+  align-self: start;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+}
+
+#mokuji a {
+  display: inline-block;
+  padding: 0.125rem 0.375rem;
+  border-left: 2px solid transparent;
+  color: var(--pico-muted-color, #6b7280);
+  text-decoration: none;
+  transition: color 200ms ease-out, border-color 200ms ease-out, background-color 200ms ease-out;
+}
+
+#mokuji a:hover {
+  color: var(--pico-primary, #1095c1);
+}
+
+#mokuji a[data-mokuji-active] {
+  color: var(--pico-primary, #1095c1);
+  border-left-color: currentColor;
+  background-color: var(--pico-primary-background, rgba(16, 149, 193, 0.08));
+  font-weight: 600;
+}

--- a/__sandbox__/src/App.tsx
+++ b/__sandbox__/src/App.tsx
@@ -12,6 +12,8 @@ function App() {
   const [minLevel, setMinLevel] = useState<HeadingLevel>(1);
   const [maxLevel, setMaxLevel] = useState<HeadingLevel>(6);
   const [includeBlockquoteHeadings, setIncludeBlockquoteHeadings] = useState(false);
+  const [scrollSpy, setScrollSpy] = useState(true);
+  const [scrollSpyOffset, setScrollSpyOffset] = useState(0);
 
   const destroyMokuji = useCallback(() => {
     mokujiInstanceRef.current?.destroy();
@@ -33,13 +35,15 @@ function App() {
       minLevel,
       maxLevel,
       includeBlockquoteHeadings,
+      scrollSpy,
+      scrollSpyOffset,
     });
 
     if (result) {
       mokujiInstanceRef.current = result;
       refMokuji.current?.append(result.list);
     }
-  }, [minLevel, maxLevel, includeBlockquoteHeadings, destroyMokuji]);
+  }, [minLevel, maxLevel, includeBlockquoteHeadings, scrollSpy, scrollSpyOffset, destroyMokuji]);
 
   useEffect(() => {
     create();
@@ -88,6 +92,24 @@ function App() {
             />
             includeBlockquoteHeadings
           </label>
+        </div>
+        <div>
+          <label>
+            <input type="checkbox" checked={scrollSpy} onChange={(e) => setScrollSpy(e.target.checked)} />
+            scrollSpy
+          </label>
+        </div>
+        <div>
+          <label htmlFor="scroll-spy-offset">scrollSpyOffset:</label>
+          <input
+            id="scroll-spy-offset"
+            type="number"
+            min={0}
+            step={10}
+            value={scrollSpyOffset}
+            onChange={(e) => setScrollSpyOffset(Math.max(0, Number(e.target.value) || 0))}
+            disabled={!scrollSpy}
+          />
         </div>
       </div>
       <button type="button" onClick={create}>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Mokuji } from './index';
-import { MOKUJI_LIST_DATASET_ATTRIBUTE, ANCHOR_DATASET_ATTRIBUTE } from './utils/constants';
+import { MOKUJI_LIST_DATASET_ATTRIBUTE, ANCHOR_DATASET_ATTRIBUTE, ACTIVE_DATASET_ATTRIBUTE } from './utils/constants';
 
 describe('Mokuji.js', () => {
   let container: HTMLElement;
@@ -247,5 +247,50 @@ describe('Mokuji.js', () => {
       }
     }
     expect(hrefs2.size).toBe(tocLinks2?.length); // All hrefs also unique in second call
+  });
+
+  it('marks the active TOC anchor when scrollSpy is enabled and clears it on destroy', () => {
+    const observers: Array<{ disconnect: () => void; targets: Set<Element> }> = [];
+
+    class StubIntersectionObserver {
+      targets = new Set<Element>();
+      constructor() {
+        observers.push(this);
+      }
+      observe(target: Element) {
+        this.targets.add(target);
+      }
+      unobserve(target: Element) {
+        this.targets.delete(target);
+      }
+      disconnect() {
+        this.targets.clear();
+      }
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    }
+
+    vi.stubGlobal('IntersectionObserver', StubIntersectionObserver);
+
+    container.innerHTML = `
+      <h2 id="alpha">Alpha</h2>
+      <h2 id="beta">Beta</h2>
+    `;
+    const headings = container.querySelectorAll('h2');
+    headings[0].getBoundingClientRect = () => ({ top: -50 }) as DOMRect;
+    headings[1].getBoundingClientRect = () => ({ top: 200 }) as DOMRect;
+
+    const result = Mokuji(container, { scrollSpy: true });
+    expect(result).toBeDefined();
+    expect(observers).toHaveLength(1);
+    expect(observers[0].targets.size).toBe(2);
+
+    const activeAnchor = result?.list.querySelector(`[${ACTIVE_DATASET_ATTRIBUTE}]`);
+    expect(activeAnchor?.getAttribute('href')).toBe('#alpha');
+
+    result?.destroy();
+    expect(observers[0].targets.size).toBe(0);
+    expect(result?.list.querySelector(`[${ACTIVE_DATASET_ATTRIBUTE}]`)).toBeNull();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { getFilteredHeadings } from './heading';
 import { resolveHeadingIdentities, commitHeadingIdentities } from './heading-identity';
 import { buildTocList } from './mokuji-core';
 import { insertPerHeadingAnchors } from './anchor';
+import { setupScrollSpy } from './scroll-spy';
 import { MOKUJI_LIST_DATASET_ATTRIBUTE, defaultOptions } from './utils/constants';
 
 export type MokujiResult<T extends HTMLElement = HTMLElement> = {
@@ -45,7 +46,12 @@ export const Mokuji = <T extends HTMLElement>(
 
   const insertedAnchors = options.anchorLink ? insertPerHeadingAnchors(resolved, options) : [];
 
+  const teardownScrollSpy = options.scrollSpy
+    ? setupScrollSpy(resolved, list, { offset: options.scrollSpyOffset })
+    : undefined;
+
   const destroy = () => {
+    teardownScrollSpy?.();
     list.remove();
     for (const anchor of insertedAnchors) anchor.remove();
   };

--- a/src/scroll-spy.test.ts
+++ b/src/scroll-spy.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupScrollSpy } from './scroll-spy';
+import { ACTIVE_DATASET_ATTRIBUTE } from './utils/constants';
+import type { ResolvedHeading } from './heading-identity';
+import type { HeadingLevel } from './types';
+
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  options?: IntersectionObserverInit;
+  targets = new Set<Element>();
+
+  constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+    this.callback = callback;
+    this.options = options;
+    observerInstances.push(this);
+  }
+
+  observe(target: Element): void {
+    this.targets.add(target);
+  }
+
+  unobserve(target: Element): void {
+    this.targets.delete(target);
+  }
+
+  disconnect(): void {
+    this.targets.clear();
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  trigger(): void {
+    this.callback([], this as unknown as IntersectionObserver);
+  }
+}
+
+const observerInstances: Array<MockIntersectionObserver> = [];
+
+const lastObserver = (): MockIntersectionObserver => {
+  const last = observerInstances.at(-1);
+  if (!last) throw new Error('No IntersectionObserver instance was created');
+  return last;
+};
+
+const setHeadingTop = (heading: HTMLHeadingElement, top: number): void => {
+  heading.getBoundingClientRect = () =>
+    ({ top, bottom: top + 20, left: 0, right: 100, width: 100, height: 20, x: 0, y: top }) as DOMRect;
+};
+
+const buildResolved = (headings: ReadonlyArray<HTMLHeadingElement>, level: HeadingLevel = 2): Array<ResolvedHeading> =>
+  headings.map((heading) => ({ heading, identity: heading.id, level }));
+
+const buildList = (identities: ReadonlyArray<string>): HTMLOListElement => {
+  const list = document.createElement('ol');
+  for (const id of identities) {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.setAttribute('href', `#${id}`);
+    a.textContent = id;
+    li.append(a);
+    list.append(li);
+  }
+  return list;
+};
+
+const findAnchor = (list: HTMLElement, identity: string): HTMLAnchorElement | null =>
+  list.querySelector<HTMLAnchorElement>(`a[href="#${identity}"]`);
+
+describe('setupScrollSpy', () => {
+  let body: HTMLElement;
+
+  beforeEach(() => {
+    observerInstances.length = 0;
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+    body = document.createElement('div');
+    document.body.append(body);
+  });
+
+  afterEach(() => {
+    body.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('marks the heading whose top has scrolled past the viewport top as active', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    const h2 = document.createElement('h2');
+    h2.id = 'b';
+    const h3 = document.createElement('h2');
+    h3.id = 'c';
+    body.append(h1, h2, h3);
+    setHeadingTop(h1, -200);
+    setHeadingTop(h2, -50);
+    setHeadingTop(h3, 300);
+
+    const list = buildList(['a', 'b', 'c']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1, h2, h3]), list, { offset: 0 });
+
+    expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+    expect(findAnchor(list, 'b')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+    expect(findAnchor(list, 'b')?.getAttribute('aria-current')).toBe('true');
+    expect(findAnchor(list, 'c')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+  });
+
+  it('updates the active anchor when the viewport scrolls', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    const h2 = document.createElement('h2');
+    h2.id = 'b';
+    body.append(h1, h2);
+    setHeadingTop(h1, -100);
+    setHeadingTop(h2, 200);
+
+    const list = buildList(['a', 'b']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1, h2]), list, { offset: 0 });
+
+    expect(findAnchor(list, 'a')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+    expect(findAnchor(list, 'b')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+
+    setHeadingTop(h1, -300);
+    setHeadingTop(h2, -50);
+    lastObserver().trigger();
+
+    expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+    expect(findAnchor(list, 'b')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+  });
+
+  it('respects offset so headings only count as active once their top crosses it', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    const h2 = document.createElement('h2');
+    h2.id = 'b';
+    body.append(h1, h2);
+    setHeadingTop(h1, -200);
+    setHeadingTop(h2, 120);
+
+    const list = buildList(['a', 'b']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1, h2]), list, { offset: 80 });
+
+    expect(findAnchor(list, 'a')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+    expect(findAnchor(list, 'b')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+    expect(lastObserver().options?.rootMargin).toBe('-80px 0px 0px 0px');
+
+    setHeadingTop(h2, 50);
+    lastObserver().trigger();
+
+    expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+    expect(findAnchor(list, 'b')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+  });
+
+  it('leaves no anchor active when no heading has scrolled past the offset yet', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    body.append(h1);
+    setHeadingTop(h1, 500);
+
+    const list = buildList(['a']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1]), list, { offset: 0 });
+
+    expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+    expect(findAnchor(list, 'a')?.hasAttribute('aria-current')).toBe(false);
+  });
+
+  it('disconnects the observer and clears the active state on teardown', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    body.append(h1);
+    setHeadingTop(h1, -10);
+
+    const list = buildList(['a']);
+    body.append(list);
+
+    const teardown = setupScrollSpy(buildResolved([h1]), list, { offset: 0 });
+    expect(findAnchor(list, 'a')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+
+    teardown();
+
+    expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+    expect(findAnchor(list, 'a')?.hasAttribute('aria-current')).toBe(false);
+    expect(lastObserver().targets.size).toBe(0);
+  });
+
+  it('returns a no-op teardown when no resolved headings are provided', () => {
+    const list = buildList([]);
+    body.append(list);
+
+    const teardown = setupScrollSpy([], list, { offset: 0 });
+
+    expect(observerInstances).toHaveLength(0);
+    expect(() => teardown()).not.toThrow();
+  });
+
+  it('does not toggle attributes when the active heading does not change', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    body.append(h1);
+    setHeadingTop(h1, -10);
+
+    const list = buildList(['a']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1]), list, { offset: 0 });
+    const anchor = findAnchor(list, 'a');
+    if (!anchor) throw new Error('anchor missing');
+
+    const removeSpy = vi.spyOn(anchor, 'removeAttribute');
+    const setSpy = vi.spyOn(anchor, 'setAttribute');
+
+    lastObserver().trigger();
+
+    expect(removeSpy).not.toHaveBeenCalled();
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/scroll-spy.ts
+++ b/src/scroll-spy.ts
@@ -1,0 +1,66 @@
+import type { ResolvedHeading } from './heading-identity';
+import { ACTIVE_DATASET_ATTRIBUTE } from './utils/constants';
+
+const ARIA_CURRENT_ATTRIBUTE = 'aria-current';
+const ARIA_CURRENT_VALUE = 'true';
+
+const applyActiveState = (
+  next: HTMLAnchorElement | undefined,
+  current: HTMLAnchorElement | undefined,
+): HTMLAnchorElement | undefined => {
+  if (next === current) return current;
+  if (current) {
+    current.removeAttribute(ACTIVE_DATASET_ATTRIBUTE);
+    current.removeAttribute(ARIA_CURRENT_ATTRIBUTE);
+  }
+  if (next) {
+    next.setAttribute(ACTIVE_DATASET_ATTRIBUTE, 'true');
+    next.setAttribute(ARIA_CURRENT_ATTRIBUTE, ARIA_CURRENT_VALUE);
+  }
+  return next;
+};
+
+const findActiveIndex = (resolved: ReadonlyArray<ResolvedHeading>, offset: number): number => {
+  let activeIndex = -1;
+  for (const [i, r] of resolved.entries()) {
+    if (r.heading.getBoundingClientRect().top - offset <= 0) {
+      activeIndex = i;
+    } else {
+      break;
+    }
+  }
+  return activeIndex;
+};
+
+/**
+ * Mark the TOC list anchor whose heading is currently nearest the top of the viewport.
+ * Active = last heading in document order whose top has scrolled past `offset` pixels.
+ */
+export const setupScrollSpy = (
+  resolved: ReadonlyArray<ResolvedHeading>,
+  list: HTMLElement,
+  options: { offset: number },
+): (() => void) => {
+  if (resolved.length === 0) return () => {};
+
+  const offset = options.offset;
+  const anchors = list.querySelectorAll<HTMLAnchorElement>('a');
+  let active: HTMLAnchorElement | undefined;
+
+  const recompute = (): void => {
+    const index = findActiveIndex(resolved, offset);
+    active = applyActiveState(index >= 0 ? anchors[index] : undefined, active);
+  };
+
+  const observer = new IntersectionObserver(recompute, {
+    rootMargin: `-${offset}px 0px 0px 0px`,
+    threshold: [0, 1],
+  });
+  for (const r of resolved) observer.observe(r.heading);
+  recompute();
+
+  return () => {
+    observer.disconnect();
+    active = applyActiveState(undefined, active);
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,4 +68,19 @@ export type MokujiOption = {
    * Default: false (blockquote headings are excluded)
    */
   includeBlockquoteHeadings?: boolean;
+
+  /**
+   * Whether to track which heading is closest above the viewport top and mark its
+   * TOC list anchor with `data-mokuji-active="true"` and `aria-current="true"`.
+   * Cleanup is handled by the result's `destroy()` method.
+   * Default: false
+   */
+  scrollSpy?: boolean;
+
+  /**
+   * Pixel offset from the viewport top used as the active boundary, useful when a
+   * sticky header occupies the top of the viewport. Only applies when `scrollSpy: true`.
+   * Default: 0
+   */
+  scrollSpyOffset?: number;
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,6 +2,7 @@ import type { MokujiOption } from '../types';
 
 export const MOKUJI_LIST_DATASET_ATTRIBUTE = 'data-mokuji-list';
 export const ANCHOR_DATASET_ATTRIBUTE = 'data-mokuji-anchor';
+export const ACTIVE_DATASET_ATTRIBUTE = 'data-mokuji-active';
 
 export const defaultOptions: Required<MokujiOption> = {
   anchorType: true,
@@ -13,4 +14,6 @@ export const defaultOptions: Required<MokujiOption> = {
   minLevel: 1,
   maxLevel: 6,
   includeBlockquoteHeadings: false,
+  scrollSpy: false,
+  scrollSpyOffset: 0,
 } as const;


### PR DESCRIPTION
## Summary
- Add `scrollSpy` and `scrollSpyOffset` options to `Mokuji()`. When enabled, an `IntersectionObserver` tracks which heading is currently nearest the top of the viewport and marks the corresponding TOC list anchor with `data-mokuji-active="true"` and `aria-current="true"`. Cleanup is wired into the existing instance-scoped `destroy()`.
- The active anchor is resolved by positional matching against the resolved heading list (i-th anchor in document order = i-th `ResolvedHeading`) so `ResolvedHeading.identity` remains the single source of truth and `href` is never re-parsed.
- Update `__sandbox__` to demonstrate the feature: a `scrollSpy` toggle and offset input, a sticky TOC column, and accent-color styling for `[data-mokuji-active]`.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npm run test` — 66 / 66 passing (incl. 7 new unit tests + 1 integration test)
- [x] `npm run build` — `dist/index.d.ts` exposes both new options
- [x] `__sandbox__` build — `npx vite build` succeeds against the rebuilt dist
- [ ] Manual smoke: `cd __sandbox__ && npm run dev`, scroll the page, and confirm the active TOC anchor updates and visibly highlights as headings cross the viewport top (try non-zero `scrollSpyOffset` for the sticky-header case)