### PR TITLE
fix: correct four edge-case bugs in TOC generation

### DIFF
--- a/src/heading-identity.test.ts
+++ b/src/heading-identity.test.ts
@@ -54,6 +54,12 @@ describe('resolveHeadingIdentities', () => {
     expect(r.identity).toBe('foobar_baz');
   });
 
+  it('strips every colon when the text contains multiple colons', () => {
+    const h = createHeading(2, 'a:b:c d');
+    const [r] = resolveHeadingIdentities([h], { anchorType: true });
+    expect(r.identity).toBe('abc_d');
+  });
+
   it('falls back to mokuji-heading-${i} for empty text without id', () => {
     const h1 = createHeading(2, '');
     const h2 = createHeading(3, '');

--- a/src/heading-identity.ts
+++ b/src/heading-identity.ts
@@ -19,7 +19,7 @@ export type ResolvedHeading = {
 };
 
 const replaceSpacesWithUnderscores = (text: string): string => {
-  return text.replaceAll(WHITESPACE_PATTERN, '_').replace(COLON_CHARACTER, '');
+  return text.replaceAll(WHITESPACE_PATTERN, '_').replaceAll(COLON_CHARACTER, '');
 };
 
 const convertToWikipediaStyleAnchor = (anchor: string): string => {

--- a/src/heading-identity.ts
+++ b/src/heading-identity.ts
@@ -1,4 +1,5 @@
 import { getHeadingLevel } from './heading';
+import { getHeadingText } from './utils/dom';
 import type { HeadingLevel } from './types';
 
 const WHITESPACE_PATTERN = /\s+/g;
@@ -46,7 +47,7 @@ const safeDecodeURIComponent = (encoded: string): string => {
 const computeInitialIdentity = (heading: HTMLHeadingElement, isWikipediaStyle: boolean): string => {
   const existingId = heading.getAttribute('id')?.trim();
   if (existingId) return existingId;
-  const text = (heading.textContent ?? '').trim();
+  const text = getHeadingText(heading).trim();
   return text ? generateAnchorText(text, isWikipediaStyle) : '';
 };
 

--- a/src/heading.test.ts
+++ b/src/heading.test.ts
@@ -82,6 +82,39 @@ describe('heading', () => {
       expect(filtered.map((h) => h.textContent)).toEqual(['Normal heading', 'Quoted heading', 'Another heading']);
     });
 
+    it('keeps headings when the search root itself is inside a blockquote', () => {
+      container.innerHTML = `
+        <blockquote>
+          <div>
+            <h2>Inside root</h2>
+          </div>
+        </blockquote>
+      `;
+      const root = container.querySelector<HTMLElement>('div');
+      if (!root) throw new Error('root missing');
+
+      const filtered = getFilteredHeadings(root, 1, 6);
+
+      expect(filtered.map((h) => h.textContent)).toEqual(['Inside root']);
+    });
+
+    it('keeps direct headings when the search root is a blockquote, excluding nested quotes', () => {
+      container.innerHTML = `
+        <blockquote>
+          <h2>Quoted root</h2>
+          <blockquote>
+            <h3>Nested quote</h3>
+          </blockquote>
+        </blockquote>
+      `;
+      const root = container.querySelector<HTMLElement>('blockquote');
+      if (!root) throw new Error('root missing');
+
+      const filtered = getFilteredHeadings(root, 1, 6);
+
+      expect(filtered.map((h) => h.textContent)).toEqual(['Quoted root']);
+    });
+
     it('excludes headings in nested blockquotes', () => {
       container.innerHTML = `
         <h2>Top</h2>

--- a/src/heading.ts
+++ b/src/heading.ts
@@ -32,5 +32,10 @@ export const getFilteredHeadings = (
     return allHeadings;
   }
 
-  return allHeadings.filter((heading) => !heading.closest('blockquote'));
+  // Only blockquotes strictly inside the search root count as quote boundaries;
+  // contains() is self-inclusive, so a blockquote passed as the root must be allowed.
+  return allHeadings.filter((heading) => {
+    const blockquote = heading.closest('blockquote');
+    return !blockquote || blockquote === element || !element.contains(blockquote);
+  });
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -249,6 +249,19 @@ describe('Mokuji.js', () => {
     expect(hrefs2.size).toBe(tocLinks2?.length); // All hrefs also unique in second call
   });
 
+  it('keeps TOC link text free of anchor symbols on repeated calls', () => {
+    container.innerHTML = `
+      <h1>Title</h1>
+      <h2>Section 1</h2>
+    `;
+
+    Mokuji(container, { anchorLink: true, anchorLinkSymbol: '#' });
+    const result = Mokuji(container, { anchorLink: true, anchorLinkSymbol: '#' });
+
+    const linkTexts = [...(result?.list.querySelectorAll('a') || [])].map((a) => a.textContent);
+    expect(linkTexts).toEqual(['Title', 'Section 1']);
+  });
+
   it('marks the active TOC anchor when scrollSpy is enabled and clears it on destroy', () => {
     const observers: Array<{ disconnect: () => void; targets: Set<Element> }> = [];
 

--- a/src/mokuji-core.ts
+++ b/src/mokuji-core.ts
@@ -1,9 +1,9 @@
-import { createElement } from './utils/dom';
+import { createElement, getHeadingText } from './utils/dom';
 import type { ResolvedHeading } from './heading-identity';
 import type { AnchorContainerTagName } from './types';
 
 type TocItem = {
-  text: string | null;
+  text: string;
   href: string;
   children: TocItem[];
 };
@@ -16,7 +16,7 @@ const buildTocHierarchy = (resolved: ReadonlyArray<ResolvedHeading>): TocItem[] 
 
   for (const r of resolved) {
     const newItem: TocItem = {
-      text: r.heading.textContent,
+      text: getHeadingText(r.heading),
       href: `#${r.identity}`,
       children: [],
     };

--- a/src/scroll-spy.test.ts
+++ b/src/scroll-spy.test.ts
@@ -156,6 +156,26 @@ describe('setupScrollSpy', () => {
     expect(findAnchor(list, 'b')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
   });
 
+  it('accepts a negative offset and produces a valid expanded root margin', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    body.append(h1);
+    setHeadingTop(h1, -5);
+
+    const list = buildList(['a']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1]), list, { offset: -10 });
+
+    expect(lastObserver().options?.rootMargin).toBe('10px 0px 0px 0px');
+    expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+
+    setHeadingTop(h1, -15);
+    lastObserver().trigger();
+
+    expect(findAnchor(list, 'a')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+  });
+
   it('leaves no anchor active when no heading has scrolled past the offset yet', () => {
     const h1 = document.createElement('h2');
     h1.id = 'a';

--- a/src/scroll-spy.ts
+++ b/src/scroll-spy.ts
@@ -53,7 +53,7 @@ export const setupScrollSpy = (
   };
 
   const observer = new IntersectionObserver(recompute, {
-    rootMargin: `-${offset}px 0px 0px 0px`,
+    rootMargin: `${-offset}px 0px 0px 0px`,
     threshold: [0, 1],
   });
   for (const r of resolved) observer.observe(r.heading);

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,3 +1,4 @@
+import { ANCHOR_DATASET_ATTRIBUTE } from './constants';
 import type { HeadingLevel } from '../types';
 
 export const getAllHeadingElements = (
@@ -22,4 +23,19 @@ export const removeAllElements = (elements: NodeListOf<Element> | Element[]): vo
   for (const element of elements) {
     element.remove();
   }
+};
+
+/**
+ * Heading text excluding per-heading anchors inserted by a previous Mokuji call,
+ * so repeated invocations never leak the anchor symbol into derived text.
+ */
+export const getHeadingText = (heading: HTMLHeadingElement): string => {
+  let text = '';
+  for (const node of heading.childNodes) {
+    if (node instanceof Element && node.hasAttribute(ANCHOR_DATASET_ATTRIBUTE)) {
+      continue;
+    }
+    text += node.textContent ?? '';
+  }
+  return text;
 };


### PR DESCRIPTION
## Summary

Four independent edge-case bugs surfaced while reviewing `src/`. Each is fixed in its own commit with a colocated regression test.

- **Anchor symbol leaks into heading text on re-invocation** (`utils/dom.ts`, `heading-identity.ts`, `mokuji-core.ts`). Calling `Mokuji()` twice on the same element with `anchorLink: true` folded the previously inserted anchor symbol into `heading.textContent`, so regenerated TOC links and ids captured the symbol (e.g. `#two` instead of `two`). A new `getHeadingText()` helper reads heading text while skipping child elements carrying the mokuji anchor attribute.
- **Empty TOC when the target element is inside a `<blockquote>`** (`heading.ts`). `closest('blockquote')` climbs past the search root, so a target element nested in a blockquote made every heading count as quoted. Only blockquotes strictly contained by the root are now treated as quote boundaries.
- **Negative `scrollSpyOffset` crashes setup** (`scroll-spy.ts`). A negative offset produced a `--Npx` rootMargin, which the `IntersectionObserver` constructor rejects. The margin is now built from the negated value so both signs format correctly. Negative offsets are valid input (`findActiveIndex` uses `top - offset`).
- **Only the first colon stripped in Wikipedia-style anchors** (`heading-identity.ts`). `String.prototype.replace` with a string pattern removes one match, so `a:b:c` produced a half-encoded `ab.3Ac`. Switched to `replaceAll`.

No public API or option behavior changes; these are correctness fixes for previously-broken inputs.

## Test plan

- [x] `npm run test` — 71 passed (8 files), including 5 new regression tests
- [x] `npx eslint src/` — no issues
- [x] `npx tsc --noEmit` — no errors in `src/`
- [x] `npm run build` — succeeds