### PR TITLE
Improve TOC scroll spy performance and demo UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Returns `undefined` if no headings are found.
   minLevel: 1,
   maxLevel: 6,
   includeBlockquoteHeadings: false,
+  scrollSpy: false,
+  scrollSpyOffset: 0,
 }
 ```
 
@@ -256,6 +258,33 @@ const result = Mokuji(element);
 // Include blockquote headings
 const result = Mokuji(element, {
   includeBlockquoteHeadings: true,
+});
+```
+
+### `scrollSpy`
+
+(default: `false`)
+
+Whether to mark the active table-of-contents link while the user scrolls.
+
+When enabled, the active TOC link receives `data-mokuji-active="true"` and `aria-current="true"`. The active heading is the closest heading above the viewport offset, or the first visible heading before any heading has crossed that offset.
+
+```javascript
+const result = Mokuji(element, {
+  scrollSpy: true,
+});
+```
+
+### `scrollSpyOffset`
+
+(default: `0`)
+
+Pixel offset from the viewport top used by `scrollSpy`. Set this when a sticky header covers the top of the document.
+
+```javascript
+const result = Mokuji(element, {
+  scrollSpy: true,
+  scrollSpyOffset: 64,
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ const result = Mokuji(element, {
 
 Whether to mark the active table-of-contents link while the user scrolls.
 
-When enabled, the active TOC link receives `data-mokuji-active="true"` and `aria-current="true"`. The active heading is the visually closest heading above the viewport offset, or the first visible heading before any heading has crossed that offset.
+When enabled, the active TOC link receives `data-mokuji-active="true"` and `aria-current="true"`. The active heading is the visually closest heading above the viewport offset. When `scrollSpyOffset` is zero or positive, the first visible heading is used before any heading has crossed that offset.
 
 ```javascript
 const result = Mokuji(element, {

--- a/README.md
+++ b/README.md
@@ -267,12 +267,21 @@ const result = Mokuji(element, {
 
 Whether to mark the active table-of-contents link while the user scrolls.
 
-When enabled, the active TOC link receives `data-mokuji-active="true"` and `aria-current="true"`. The active heading is the closest heading above the viewport offset, or the first visible heading before any heading has crossed that offset.
+When enabled, the active TOC link receives `data-mokuji-active="true"` and `aria-current="true"`. The active heading is the visually closest heading above the viewport offset, or the first visible heading before any heading has crossed that offset.
 
 ```javascript
 const result = Mokuji(element, {
   scrollSpy: true,
 });
+```
+
+Add CSS for the active state in your own UI:
+
+```css
+[data-mokuji-list] a[data-mokuji-active] {
+  font-weight: 600;
+  color: currentColor;
+}
 ```
 
 ### `scrollSpyOffset`

--- a/__sandbox__/src/App.css
+++ b/__sandbox__/src/App.css
@@ -182,7 +182,8 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.3rem 0;
+  min-height: 2rem;
+  padding: 0.5rem 0;
   cursor: pointer;
 }
 
@@ -403,6 +404,11 @@ body {
 }
 
 .content a[data-mokuji-anchor] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  min-height: 2rem;
   margin-right: 0.4em;
   color: var(--faint);
   text-decoration: none;
@@ -459,6 +465,7 @@ body {
 
   .layout {
     grid-template-columns: 1fr;
+    gap: 1.5rem;
     padding-top: 1.5rem;
   }
 
@@ -468,6 +475,6 @@ body {
   }
 
   #mokuji {
-    max-height: 45vh;
+    max-height: 30vh;
   }
 }

--- a/__sandbox__/src/App.css
+++ b/__sandbox__/src/App.css
@@ -470,8 +470,13 @@ body {
   }
 
   .pane {
+    order: 2;
     position: static;
     max-height: none;
+  }
+
+  .content {
+    order: 1;
   }
 
   #mokuji {

--- a/__sandbox__/src/App.tsx
+++ b/__sandbox__/src/App.tsx
@@ -58,21 +58,39 @@ function App() {
     const container = refMokuji.current;
     if (!container) return;
 
+    let activeTarget: HTMLElement | undefined;
+    let animationFrame = 0;
+
+    const scrollActiveTargetIntoView = () => {
+      animationFrame = 0;
+      if (!activeTarget) return;
+
+      const containerRect = container.getBoundingClientRect();
+      const linkRect = activeTarget.getBoundingClientRect();
+      if (linkRect.top < containerRect.top || linkRect.bottom > containerRect.bottom) {
+        const centerDelta = linkRect.top - containerRect.top - (containerRect.height - linkRect.height) / 2;
+        container.scrollTop += centerDelta;
+      }
+    };
+
+    const scheduleScrollIntoView = (target: HTMLElement) => {
+      activeTarget = target;
+      if (animationFrame) return;
+      animationFrame = requestAnimationFrame(scrollActiveTargetIntoView);
+    };
+
     const observer = new MutationObserver((mutations) => {
       for (const { target } of mutations) {
         if (!(target instanceof HTMLElement) || !target.hasAttribute(ACTIVE_ATTRIBUTE)) continue;
-
-        const containerRect = container.getBoundingClientRect();
-        const linkRect = target.getBoundingClientRect();
-        if (linkRect.top < containerRect.top || linkRect.bottom > containerRect.bottom) {
-          const centerDelta = linkRect.top - containerRect.top - (containerRect.height - linkRect.height) / 2;
-          container.scrollTop += centerDelta;
-        }
+        scheduleScrollIntoView(target);
         return;
       }
     });
     observer.observe(container, { subtree: true, attributes: true, attributeFilter: [ACTIVE_ATTRIBUTE] });
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (animationFrame) cancelAnimationFrame(animationFrame);
+    };
   }, []);
 
   const handleMinLevelChange = (e: ChangeEvent<HTMLSelectElement>) => {

--- a/src/anchor.test.ts
+++ b/src/anchor.test.ts
@@ -34,7 +34,7 @@ describe('insertPerHeadingAnchors', () => {
     expect(anchor).toBeTruthy();
     expect(anchor?.textContent).toBe(defaultOptions.anchorLinkSymbol);
     expect(anchor?.getAttribute('href')).toBe('#test');
-    expect(anchor?.getAttribute('aria-label')).toBe('Link to heading: Test Heading');
+    expect(anchor?.getAttribute('aria-label')).toBe('Test Heading');
     expect(anchor).toBe(heading.firstElementChild);
   });
 
@@ -108,7 +108,7 @@ describe('insertPerHeadingAnchors', () => {
     insertPerHeadingAnchors([r(heading, 'fallback-id', 2)], defaultOptions);
 
     const anchor = heading.querySelector(`[${ANCHOR_DATASET_ATTRIBUTE}]`);
-    expect(anchor?.getAttribute('aria-label')).toBe('Link to heading: fallback-id');
+    expect(anchor?.getAttribute('aria-label')).toBe('fallback-id');
   });
 
   it('returns an empty array when no resolved headings are provided', () => {

--- a/src/anchor.test.ts
+++ b/src/anchor.test.ts
@@ -34,6 +34,7 @@ describe('insertPerHeadingAnchors', () => {
     expect(anchor).toBeTruthy();
     expect(anchor?.textContent).toBe(defaultOptions.anchorLinkSymbol);
     expect(anchor?.getAttribute('href')).toBe('#test');
+    expect(anchor?.getAttribute('aria-label')).toBe('Link to heading: Test Heading');
     expect(anchor).toBe(heading.firstElementChild);
   });
 
@@ -98,6 +99,16 @@ describe('insertPerHeadingAnchors', () => {
     expect(inserted).toHaveLength(2);
     expect(h1.querySelectorAll(`[${ANCHOR_DATASET_ATTRIBUTE}]`)).toHaveLength(1);
     expect(h2.querySelectorAll(`[${ANCHOR_DATASET_ATTRIBUTE}]`)).toHaveLength(1);
+  });
+
+  it('uses the identity in the aria label when the heading text is empty', () => {
+    const heading = document.createElement('h2');
+    container.append(heading);
+
+    insertPerHeadingAnchors([r(heading, 'fallback-id', 2)], defaultOptions);
+
+    const anchor = heading.querySelector(`[${ANCHOR_DATASET_ATTRIBUTE}]`);
+    expect(anchor?.getAttribute('aria-label')).toBe('Link to heading: fallback-id');
   });
 
   it('returns an empty array when no resolved headings are provided', () => {

--- a/src/anchor.ts
+++ b/src/anchor.ts
@@ -1,4 +1,4 @@
-import { createElement, removeAllElements } from './utils/dom';
+import { createElement, getHeadingText, removeAllElements } from './utils/dom';
 import { ANCHOR_DATASET_ATTRIBUTE } from './utils/constants';
 import type { MokujiOption, AnchorLinkPosition } from './types';
 import type { ResolvedHeading } from './heading-identity';
@@ -28,6 +28,11 @@ const placeAnchorInHeading = (
   }
 };
 
+const createAnchorLabel = (heading: HTMLHeadingElement, identity: string): string => {
+  const text = getHeadingText(heading).trim();
+  return `Link to heading: ${text || identity}`;
+};
+
 export const insertPerHeadingAnchors = (
   resolved: ReadonlyArray<ResolvedHeading>,
   options: Required<MokujiOption>,
@@ -40,6 +45,7 @@ export const insertPerHeadingAnchors = (
     const anchor = template.cloneNode(false) as HTMLAnchorElement;
     anchor.href = `#${r.identity}`;
     anchor.textContent = options.anchorLinkSymbol;
+    anchor.setAttribute('aria-label', createAnchorLabel(r.heading, r.identity));
     placeAnchorInHeading(r.heading, anchor, options.anchorLinkPosition);
     inserted.push(anchor);
   }

--- a/src/anchor.ts
+++ b/src/anchor.ts
@@ -30,7 +30,7 @@ const placeAnchorInHeading = (
 
 const createAnchorLabel = (heading: HTMLHeadingElement, identity: string): string => {
   const text = getHeadingText(heading).trim();
-  return `Link to heading: ${text || identity}`;
+  return text || identity;
 };
 
 export const insertPerHeadingAnchors = (

--- a/src/scroll-spy.test.ts
+++ b/src/scroll-spy.test.ts
@@ -196,6 +196,31 @@ describe('setupScrollSpy', () => {
     expect(findAnchor(list, 'b')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
   });
 
+  it('falls back when animation frame functions are not available on window', async () => {
+    Object.defineProperty(globalThis.window, 'requestAnimationFrame', { configurable: true, value: undefined });
+    Object.defineProperty(globalThis.window, 'cancelAnimationFrame', { configurable: true, value: undefined });
+
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    const h2 = document.createElement('h2');
+    h2.id = 'b';
+    body.append(h1, h2);
+    setHeadingTop(h1, -100);
+    setHeadingTop(h2, 200);
+
+    const list = buildList(['a', 'b']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1, h2]), list, { offset: 0 });
+
+    setScrollTop(250);
+    globalThis.dispatchEvent(new Event('scroll'));
+    await new Promise((resolve) => globalThis.window.setTimeout(resolve, 0));
+
+    expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+    expect(findAnchor(list, 'b')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+  });
+
   it('respects offset so headings only count as active once their top crosses it', () => {
     const h1 = document.createElement('h2');
     h1.id = 'a';

--- a/src/scroll-spy.test.ts
+++ b/src/scroll-spy.test.ts
@@ -176,7 +176,7 @@ describe('setupScrollSpy', () => {
     expect(findAnchor(list, 'a')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
   });
 
-  it('leaves no anchor active when no heading has scrolled past the offset yet', () => {
+  it('marks the first visible heading before any heading has crossed the offset', () => {
     const h1 = document.createElement('h2');
     h1.id = 'a';
     body.append(h1);
@@ -187,8 +187,54 @@ describe('setupScrollSpy', () => {
 
     setupScrollSpy(buildResolved([h1]), list, { offset: 0 });
 
+    expect(findAnchor(list, 'a')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+    expect(findAnchor(list, 'a')?.getAttribute('aria-current')).toBe('true');
+  });
+
+  it('leaves no anchor active when every heading is below the viewport', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    body.append(h1);
+    setHeadingTop(h1, window.innerHeight + 100);
+
+    const list = buildList(['a']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1]), list, { offset: 0 });
+
     expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
     expect(findAnchor(list, 'a')?.hasAttribute('aria-current')).toBe(false);
+  });
+
+  it('uses logarithmic layout reads when selecting the active heading', () => {
+    const headings = Array.from({ length: 64 }, (_, i) => {
+      const heading = document.createElement('h2');
+      heading.id = `h-${i}`;
+      let reads = 0;
+      heading.getBoundingClientRect = () => {
+        reads++;
+        return {
+          top: i * 40 - 1200,
+          bottom: i * 40 - 1180,
+          left: 0,
+          right: 100,
+          width: 100,
+          height: 20,
+          x: 0,
+          y: 0,
+        } as DOMRect;
+      };
+      return { heading, getReads: () => reads };
+    });
+    body.append(...headings.map(({ heading }) => heading));
+
+    const list = buildList(headings.map(({ heading }) => heading.id));
+    body.append(list);
+
+    setupScrollSpy(buildResolved(headings.map(({ heading }) => heading)), list, { offset: 0 });
+
+    const totalReads = headings.reduce((sum, { getReads }) => sum + getReads(), 0);
+    expect(totalReads).toBeLessThan(16);
   });
 
   it('disconnects the observer and clears the active state on teardown', () => {

--- a/src/scroll-spy.test.ts
+++ b/src/scroll-spy.test.ts
@@ -37,6 +37,8 @@ class MockIntersectionObserver {
 }
 
 const observerInstances: Array<MockIntersectionObserver> = [];
+let frameCallbacks: FrameRequestCallback[] = [];
+let resizeCallbacks: ResizeObserverCallback[] = [];
 
 const lastObserver = (): MockIntersectionObserver => {
   const last = observerInstances.at(-1);
@@ -47,6 +49,10 @@ const lastObserver = (): MockIntersectionObserver => {
 const setHeadingTop = (heading: HTMLHeadingElement, top: number): void => {
   heading.getBoundingClientRect = () =>
     ({ top, bottom: top + 20, left: 0, right: 100, width: 100, height: 20, x: 0, y: top }) as DOMRect;
+};
+
+const setScrollTop = (scrollTop: number): void => {
+  Object.defineProperty(globalThis, 'scrollY', { configurable: true, value: scrollTop });
 };
 
 const buildResolved = (headings: ReadonlyArray<HTMLHeadingElement>, level: HeadingLevel = 2): Array<ResolvedHeading> =>
@@ -68,12 +74,49 @@ const buildList = (identities: ReadonlyArray<string>): HTMLOListElement => {
 const findAnchor = (list: HTMLElement, identity: string): HTMLAnchorElement | null =>
   list.querySelector<HTMLAnchorElement>(`a[href="#${identity}"]`);
 
+const flushAnimationFrames = (): void => {
+  const callbacks = frameCallbacks;
+  frameCallbacks = [];
+  for (const callback of callbacks) callback(0);
+};
+
+class MockResizeObserver {
+  callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    resizeCallbacks.push(callback);
+  }
+
+  observe(): void {}
+
+  unobserve(): void {}
+
+  disconnect(): void {}
+}
+
+const triggerResize = (): void => {
+  for (const callback of resizeCallbacks) callback([], {} as ResizeObserver);
+};
+
 describe('setupScrollSpy', () => {
   let body: HTMLElement;
 
   beforeEach(() => {
     observerInstances.length = 0;
+    frameCallbacks = [];
+    resizeCallbacks = [];
     vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    vi.stubGlobal('requestAnimationFrame', function (this: typeof globalThis, callback: FrameRequestCallback) {
+      expect(this).toBe(globalThis);
+      frameCallbacks.push(callback);
+      return frameCallbacks.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', function (this: typeof globalThis) {
+      expect(this).toBe(globalThis);
+    });
+    setScrollTop(0);
     body = document.createElement('div');
     document.body.append(body);
   });
@@ -123,9 +166,31 @@ describe('setupScrollSpy', () => {
     expect(findAnchor(list, 'a')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
     expect(findAnchor(list, 'b')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
 
-    setHeadingTop(h1, -300);
-    setHeadingTop(h2, -50);
-    lastObserver().trigger();
+    setScrollTop(250);
+    globalThis.dispatchEvent(new Event('scroll'));
+    flushAnimationFrames();
+
+    expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+    expect(findAnchor(list, 'b')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+  });
+
+  it('updates the active anchor when the document receives a scroll event', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    const h2 = document.createElement('h2');
+    h2.id = 'b';
+    body.append(h1, h2);
+    setHeadingTop(h1, -100);
+    setHeadingTop(h2, 200);
+
+    const list = buildList(['a', 'b']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1, h2]), list, { offset: 0 });
+
+    setScrollTop(250);
+    document.dispatchEvent(new Event('scroll'));
+    flushAnimationFrames();
 
     expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
     expect(findAnchor(list, 'b')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
@@ -149,8 +214,9 @@ describe('setupScrollSpy', () => {
     expect(findAnchor(list, 'b')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
     expect(lastObserver().options?.rootMargin).toBe('-80px 0px 0px 0px');
 
-    setHeadingTop(h2, 50);
-    lastObserver().trigger();
+    setScrollTop(50);
+    globalThis.dispatchEvent(new Event('scroll'));
+    flushAnimationFrames();
 
     expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
     expect(findAnchor(list, 'b')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
@@ -170,8 +236,9 @@ describe('setupScrollSpy', () => {
     expect(lastObserver().options?.rootMargin).toBe('10px 0px 0px 0px');
     expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
 
-    setHeadingTop(h1, -15);
-    lastObserver().trigger();
+    setScrollTop(10);
+    globalThis.dispatchEvent(new Event('scroll'));
+    flushAnimationFrames();
 
     expect(findAnchor(list, 'a')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
   });
@@ -206,7 +273,28 @@ describe('setupScrollSpy', () => {
     expect(findAnchor(list, 'a')?.hasAttribute('aria-current')).toBe(false);
   });
 
-  it('uses logarithmic layout reads when selecting the active heading', () => {
+  it('selects the visually closest heading when visual order differs from DOM order', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    const h2 = document.createElement('h2');
+    h2.id = 'b';
+    const h3 = document.createElement('h2');
+    h3.id = 'c';
+    body.append(h1, h2, h3);
+    setHeadingTop(h1, -100);
+    setHeadingTop(h2, 200);
+    setHeadingTop(h3, -10);
+
+    const list = buildList(['a', 'b', 'c']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1, h2, h3]), list, { offset: 0 });
+
+    expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+    expect(findAnchor(list, 'c')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+  });
+
+  it('does not read heading layout while handling scroll spy notifications', () => {
     const headings = Array.from({ length: 64 }, (_, i) => {
       const heading = document.createElement('h2');
       heading.id = `h-${i}`;
@@ -232,9 +320,55 @@ describe('setupScrollSpy', () => {
     body.append(list);
 
     setupScrollSpy(buildResolved(headings.map(({ heading }) => heading)), list, { offset: 0 });
+    const readsAfterSetup = headings.reduce((sum, { getReads }) => sum + getReads(), 0);
+
+    lastObserver().trigger();
+    lastObserver().trigger();
+    flushAnimationFrames();
 
     const totalReads = headings.reduce((sum, { getReads }) => sum + getReads(), 0);
-    expect(totalReads).toBeLessThan(16);
+    expect(totalReads).toBe(readsAfterSetup);
+  });
+
+  it('refreshes measured positions after layout changes', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    const h2 = document.createElement('h2');
+    h2.id = 'b';
+    body.append(h1, h2);
+    setHeadingTop(h1, -50);
+    setHeadingTop(h2, 200);
+
+    const list = buildList(['a', 'b']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1, h2]), list, { offset: 0 });
+    expect(findAnchor(list, 'a')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+
+    setHeadingTop(h1, 200);
+    setHeadingTop(h2, -20);
+    triggerResize();
+    flushAnimationFrames();
+
+    expect(findAnchor(list, 'a')?.hasAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe(false);
+    expect(findAnchor(list, 'b')?.getAttribute(ACTIVE_DATASET_ATTRIBUTE)).toBe('true');
+  });
+
+  it('coalesces multiple observer notifications into one animation frame', () => {
+    const h1 = document.createElement('h2');
+    h1.id = 'a';
+    body.append(h1);
+    setHeadingTop(h1, -10);
+
+    const list = buildList(['a']);
+    body.append(list);
+
+    setupScrollSpy(buildResolved([h1]), list, { offset: 0 });
+    lastObserver().trigger();
+    lastObserver().trigger();
+    lastObserver().trigger();
+
+    expect(frameCallbacks).toHaveLength(1);
   });
 
   it('disconnects the observer and clears the active state on teardown', () => {
@@ -283,6 +417,7 @@ describe('setupScrollSpy', () => {
     const setSpy = vi.spyOn(anchor, 'setAttribute');
 
     lastObserver().trigger();
+    flushAnimationFrames();
 
     expect(removeSpy).not.toHaveBeenCalled();
     expect(setSpy).not.toHaveBeenCalled();

--- a/src/scroll-spy.ts
+++ b/src/scroll-spy.ts
@@ -4,6 +4,12 @@ import { ACTIVE_DATASET_ATTRIBUTE } from './utils/constants';
 const ARIA_CURRENT_ATTRIBUTE = 'aria-current';
 const ARIA_CURRENT_VALUE = 'true';
 
+type PositionedHeading = {
+  index: number;
+  top: number;
+  bottom: number;
+};
+
 const applyActiveState = (
   next: HTMLAnchorElement | undefined,
   current: HTMLAnchorElement | undefined,
@@ -20,30 +26,75 @@ const applyActiveState = (
   return next;
 };
 
-const findActiveIndex = (resolved: ReadonlyArray<ResolvedHeading>, offset: number): number => {
+const getFrameRequest = (): {
+  request: (callback: FrameRequestCallback) => number;
+  cancel: (handle: number) => void;
+} => {
+  if (typeof requestAnimationFrame === 'function' && typeof cancelAnimationFrame === 'function') {
+    return {
+      request: globalThis.window.requestAnimationFrame.bind(globalThis.window),
+      cancel: globalThis.window.cancelAnimationFrame.bind(globalThis.window),
+    };
+  }
+
+  return {
+    request: (callback) => globalThis.window.setTimeout(() => callback(performance.now()), 0),
+    cancel: (handle) => globalThis.window.clearTimeout(handle),
+  };
+};
+
+const findCommonParent = (resolved: ReadonlyArray<ResolvedHeading>): Element | undefined => {
+  let parent: Element | undefined = resolved[0]?.heading.parentElement ?? undefined;
+  while (parent) {
+    const current = parent;
+    if (resolved.every((r) => current.contains(r.heading))) return current;
+    parent = current.parentElement ?? undefined;
+  }
+  return undefined;
+};
+
+const measurePositions = (resolved: ReadonlyArray<ResolvedHeading>): PositionedHeading[] => {
+  const scrollTop = window.scrollY;
+  const positions = resolved.map((r, index) => {
+    const rect = r.heading.getBoundingClientRect();
+    return { index, top: rect.top + scrollTop, bottom: rect.bottom + scrollTop };
+  });
+  // eslint-disable-next-line unicorn/no-array-sort -- Keep the library target at ES2022 without Array.prototype.toSorted.
+  return positions.sort((a, b) => a.top - b.top || a.index - b.index);
+};
+
+const findActiveIndex = (
+  positions: ReadonlyArray<PositionedHeading>,
+  offset: number,
+  scrollTop: number,
+  viewportHeight: number,
+): number => {
   let low = 0;
-  let high = resolved.length - 1;
-  let activeIndex = -1;
+  let high = positions.length - 1;
+  let activePosition: PositionedHeading | undefined;
+  const boundary = scrollTop + offset;
 
   while (low <= high) {
     const middle = Math.floor((low + high) / 2);
-    if (resolved[middle].heading.getBoundingClientRect().top - offset <= 0) {
-      activeIndex = middle;
+    if (positions[middle].top <= boundary) {
+      activePosition = positions[middle];
       low = middle + 1;
     } else {
       high = middle - 1;
     }
   }
 
-  if (activeIndex >= 0 || offset < 0) return activeIndex;
+  if (activePosition) return activePosition.index;
+  if (offset < 0) return -1;
 
-  const firstRect = resolved[0].heading.getBoundingClientRect();
-  return firstRect.top < window.innerHeight && firstRect.bottom >= offset ? 0 : -1;
+  const viewportBottom = scrollTop + viewportHeight;
+  const firstVisible = positions.find((position) => position.top < viewportBottom && position.bottom >= boundary);
+  return firstVisible?.index ?? -1;
 };
 
 /**
  * Mark the TOC list anchor whose heading is currently nearest the top of the viewport.
- * Active = last heading in document order whose top has scrolled past `offset` pixels,
+ * Active = visually closest heading above the viewport offset,
  * or the first visible heading before the document has crossed that boundary.
  */
 export const setupScrollSpy = (
@@ -55,22 +106,58 @@ export const setupScrollSpy = (
 
   const offset = options.offset;
   const anchors = list.querySelectorAll<HTMLAnchorElement>('a');
+  const frame = getFrameRequest();
+  let positions = measurePositions(resolved);
   let active: HTMLAnchorElement | undefined;
+  let pendingFrame = 0;
+  let pendingRefresh = false;
 
-  const recompute = (): void => {
-    const index = findActiveIndex(resolved, offset);
+  const recompute = (refreshPositions: boolean): void => {
+    if (refreshPositions) positions = measurePositions(resolved);
+    const index = findActiveIndex(positions, offset, window.scrollY, window.innerHeight);
     active = applyActiveState(index >= 0 ? anchors[index] : undefined, active);
   };
 
-  const observer = new IntersectionObserver(recompute, {
+  const scheduleRecompute = (refreshPositions: boolean): void => {
+    pendingRefresh ||= refreshPositions;
+    if (pendingFrame) return;
+    pendingFrame = frame.request(() => {
+      pendingFrame = 0;
+      const shouldRefresh = pendingRefresh;
+      pendingRefresh = false;
+      recompute(shouldRefresh);
+    });
+  };
+
+  const observer = new IntersectionObserver(() => scheduleRecompute(false), {
     rootMargin: `${-offset}px 0px 0px 0px`,
     threshold: [0, 1],
   });
   for (const r of resolved) observer.observe(r.heading);
-  recompute();
+  recompute(false);
+
+  const commonParent = findCommonParent(resolved);
+  let resizeObserver: ResizeObserver | undefined;
+  if (commonParent && typeof ResizeObserver === 'function') {
+    resizeObserver = new ResizeObserver(() => scheduleRecompute(true));
+    resizeObserver.observe(commonParent);
+  }
+  const handleScroll = () => scheduleRecompute(false);
+  const handleResize = () => scheduleRecompute(true);
+  window.addEventListener('scroll', handleScroll, { passive: true });
+  document.addEventListener('scroll', handleScroll, { passive: true });
+  window.addEventListener('resize', handleResize);
 
   return () => {
+    if (pendingFrame) {
+      frame.cancel(pendingFrame);
+      pendingFrame = 0;
+    }
     observer.disconnect();
+    resizeObserver?.disconnect();
+    window.removeEventListener('scroll', handleScroll);
+    document.removeEventListener('scroll', handleScroll);
+    window.removeEventListener('resize', handleResize);
     active = applyActiveState(undefined, active);
   };
 };

--- a/src/scroll-spy.ts
+++ b/src/scroll-spy.ts
@@ -30,10 +30,12 @@ const getFrameRequest = (): {
   request: (callback: FrameRequestCallback) => number;
   cancel: (handle: number) => void;
 } => {
-  if (typeof requestAnimationFrame === 'function' && typeof cancelAnimationFrame === 'function') {
+  const requestFrame = globalThis.window.requestAnimationFrame;
+  const cancelFrame = globalThis.window.cancelAnimationFrame;
+  if (typeof requestFrame === 'function' && typeof cancelFrame === 'function') {
     return {
-      request: globalThis.window.requestAnimationFrame.bind(globalThis.window),
-      cancel: globalThis.window.cancelAnimationFrame.bind(globalThis.window),
+      request: requestFrame.bind(globalThis.window),
+      cancel: cancelFrame.bind(globalThis.window),
     };
   }
 
@@ -95,7 +97,8 @@ const findActiveIndex = (
 /**
  * Mark the TOC list anchor whose heading is currently nearest the top of the viewport.
  * Active = visually closest heading above the viewport offset,
- * or the first visible heading before the document has crossed that boundary.
+ * or, for zero and positive offsets, the first visible heading before the
+ * document has crossed that boundary.
  */
 export const setupScrollSpy = (
   resolved: ReadonlyArray<ResolvedHeading>,

--- a/src/scroll-spy.ts
+++ b/src/scroll-spy.ts
@@ -21,20 +21,30 @@ const applyActiveState = (
 };
 
 const findActiveIndex = (resolved: ReadonlyArray<ResolvedHeading>, offset: number): number => {
+  let low = 0;
+  let high = resolved.length - 1;
   let activeIndex = -1;
-  for (const [i, r] of resolved.entries()) {
-    if (r.heading.getBoundingClientRect().top - offset <= 0) {
-      activeIndex = i;
+
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    if (resolved[middle].heading.getBoundingClientRect().top - offset <= 0) {
+      activeIndex = middle;
+      low = middle + 1;
     } else {
-      break;
+      high = middle - 1;
     }
   }
-  return activeIndex;
+
+  if (activeIndex >= 0 || offset < 0) return activeIndex;
+
+  const firstRect = resolved[0].heading.getBoundingClientRect();
+  return firstRect.top < window.innerHeight && firstRect.bottom >= offset ? 0 : -1;
 };
 
 /**
  * Mark the TOC list anchor whose heading is currently nearest the top of the viewport.
- * Active = last heading in document order whose top has scrolled past `offset` pixels.
+ * Active = last heading in document order whose top has scrolled past `offset` pixels,
+ * or the first visible heading before the document has crossed that boundary.
  */
 export const setupScrollSpy = (
   resolved: ReadonlyArray<ResolvedHeading>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,8 @@ export type MokujiOption = {
    * Whether to track the active heading and mark its TOC list anchor with
    * `data-mokuji-active="true"` and `aria-current="true"`.
    * The active heading is the visually closest heading above the viewport offset,
-   * or the first visible heading before any heading has crossed that offset.
+   * or, when the offset is zero or positive, the first visible heading before any
+   * heading has crossed that offset.
    * Cleanup is handled by the result's `destroy()` method.
    * Default: false
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,8 +70,10 @@ export type MokujiOption = {
   includeBlockquoteHeadings?: boolean;
 
   /**
-   * Whether to track which heading is closest above the viewport top and mark its
-   * TOC list anchor with `data-mokuji-active="true"` and `aria-current="true"`.
+   * Whether to track the active heading and mark its TOC list anchor with
+   * `data-mokuji-active="true"` and `aria-current="true"`.
+   * The active heading is the closest heading above the viewport offset, or the
+   * first visible heading before any heading has crossed that offset.
    * Cleanup is handled by the result's `destroy()` method.
    * Default: false
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,8 +72,8 @@ export type MokujiOption = {
   /**
    * Whether to track the active heading and mark its TOC list anchor with
    * `data-mokuji-active="true"` and `aria-current="true"`.
-   * The active heading is the closest heading above the viewport offset, or the
-   * first visible heading before any heading has crossed that offset.
+   * The active heading is the visually closest heading above the viewport offset,
+   * or the first visible heading before any heading has crossed that offset.
    * Cleanup is handled by the result's `destroy()` method.
    * Default: false
    */


### PR DESCRIPTION
## Summary
- Optimize `scrollSpy` by caching measured heading positions, coalescing active-state updates with animation frames, and refreshing measurements when layout can change.
- Add accessible labels for generated per-heading anchor links and document the `scrollSpy` options and active-link styling hook.
- Improve the sandbox demo by keeping the active TOC item visible and preserving a better mobile reading order.

## Root Cause
The scroll spy previously evaluated heading layout during active-heading selection and relied primarily on observer notifications. That made active-state updates more expensive on long documents and could miss updates in real browser scrolling paths. Generated heading anchor links also lacked explicit accessible labels.

## Validation
- Ran the unit test suite.
- Ran TypeScript type checks.
- Ran ESLint.
- Built the library bundle.
- Built and type-checked the sandbox demo.
- Manually checked desktop and mobile browser behavior for active TOC updates, active TOC visibility, responsive layout, horizontal overflow, and runtime exceptions.