### PR TITLE
Add Vitest benchmark regression checks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,6 +38,15 @@ npx tsc --noEmit
 # Run tests with coverage
 npx vitest run --coverage
 
+# Run benchmarks
+npm run bench
+
+# Save pre-change benchmark baseline
+npm run bench:baseline
+
+# Compare current benchmark results with saved baseline
+npm run bench:compare
+
 # Format code
 npm run format
 ```
@@ -165,6 +174,13 @@ The pipeline orchestrated by `Mokuji()`:
 - Optimize critical rendering path (Steve Souders principles)
 - Avoid unnecessary re-renders and DOM manipulations
 
+### Benchmark Regression Checks
+
+- Before making performance-sensitive changes, run `npm run bench:baseline` to save the current benchmark results to `tmp/bench-baseline.json`.
+- After making changes, run `npm run bench:compare` and confirm the changed code has not regressed against the saved baseline.
+- Treat a benchmark as suspicious when `hz` drops or `mean` / `median` increases beyond normal run-to-run variance. Re-run the benchmark before concluding there is a regression.
+- Include the before / after benchmark result summary in the final report when benchmark checks are relevant to the task.
+
 ## Recent Architectural Decisions
 
 - **RFC 3986 Compliance**: Standard anchor generation (`anchorType: false`) now uses proper URL encoding via `encodeURIComponent`
@@ -195,4 +211,5 @@ The pipeline orchestrated by `Mokuji()`:
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the user.
 - When modifying code, preserve the existing code style and patterns.
 - Always run tests and linting after making changes.
+- Run benchmarks before and after performance-sensitive changes and confirm there is no regression.
 - Focus on maintaining backward compatibility unless explicitly instructed otherwise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "README.md"
   ],
   "scripts": {
+    "bench": "vitest bench --run",
+    "bench:baseline": "mkdir -p tmp && vitest bench --run --outputJson tmp/bench-baseline.json",
+    "bench:compare": "vitest bench --run --compare tmp/bench-baseline.json",
     "build": "tsdown",
     "dev": "tsdown --watch",
     "lint": "eslint --cache ./src/**/*.ts",

--- a/src/mokuji.bench.ts
+++ b/src/mokuji.bench.ts
@@ -1,0 +1,96 @@
+import { bench, describe } from 'vitest';
+import { Mokuji } from './index';
+import type { MokujiOption } from './types';
+
+const options = {
+  time: 1000,
+  warmupTime: 300,
+  warmupIterations: 10,
+};
+
+const createHeadingText = (index: number, duplicateHeadings: boolean): string => {
+  if (duplicateHeadings) {
+    return `Repeated heading ${index % 10}`;
+  }
+  return `Heading ${index}`;
+};
+
+const createContent = (
+  headingCount: number,
+  fixtureOptions: { duplicateHeadings?: boolean; includeBlockquotes?: boolean } = {},
+): HTMLElement => {
+  const container = document.createElement('main');
+  const duplicateHeadings = fixtureOptions.duplicateHeadings ?? false;
+  const includeBlockquotes = fixtureOptions.includeBlockquotes ?? false;
+
+  for (let i = 0; i < headingCount; i++) {
+    const heading = document.createElement(`h${(i % 6) + 1}`) as HTMLHeadingElement;
+    heading.textContent = createHeadingText(i, duplicateHeadings);
+
+    if (includeBlockquotes && i % 5 === 0) {
+      const blockquote = document.createElement('blockquote');
+      blockquote.append(heading);
+      container.append(blockquote);
+    } else {
+      container.append(heading);
+    }
+
+    const paragraph = document.createElement('p');
+    paragraph.textContent = `Paragraph ${i}`;
+    container.append(paragraph);
+  }
+
+  return container;
+};
+
+const runMokuji = (
+  headingCount: number,
+  mokujiOptions?: MokujiOption,
+  fixtureOptions?: Parameters<typeof createContent>[1],
+): void => {
+  const container = createContent(headingCount, fixtureOptions);
+  const result = Mokuji(container, mokujiOptions);
+  result?.destroy();
+};
+
+describe('Mokuji benchmark', () => {
+  bench(
+    'generate toc: 100 headings',
+    () => {
+      runMokuji(100);
+    },
+    options,
+  );
+
+  bench(
+    'generate toc with anchor links: 100 headings',
+    () => {
+      runMokuji(100, { anchorLink: true });
+    },
+    options,
+  );
+
+  bench(
+    'generate toc with duplicate headings: 1000 headings',
+    () => {
+      runMokuji(1000, undefined, { duplicateHeadings: true });
+    },
+    options,
+  );
+
+  bench(
+    'generate toc excluding blockquote headings: 1000 headings',
+    () => {
+      runMokuji(1000, undefined, { includeBlockquotes: true });
+    },
+    options,
+  );
+
+  bench(
+    'generate toc: 1000 headings',
+    () => {
+      runMokuji(1000);
+    },
+    options,
+  );
+});


### PR DESCRIPTION
## Summary

- Add a Vitest benchmark suite for the main `Mokuji()` generation path.
- Add scripts to run benchmarks, save a pre-change baseline, and compare against that baseline.
- Link `AGENTS.md` to the shared repository assistant instructions.
- Document the benchmark regression workflow in the shared assistant instructions.

## Validation

- `tsc --noEmit --skipLibCheck`
- `eslint --cache ./src/**/*.ts`
- `vitest run`
- `vitest bench --run --outputJson tmp/bench-baseline.json`
- `vitest bench --run --compare tmp/bench-baseline.json`

The benchmark comparison did not show a meaningful regression; observed differences were within expected run-to-run variance.
